### PR TITLE
⚡ optimize sitemap generation by pre-calculating industry slugs

### DIFF
--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -136,18 +136,22 @@ async function generateSitemap() {
     priority: 0.85, // Alta prioridad para páginas de servicios
   }));
 
-  // Páginas de industrias dinámicas con prioridades diferenciadas
-  const industryPages = industries.map((industry) => {
-    const slug = industry.name.toLowerCase()
+  // Pre-calcular slugs de industrias para evitar normalización redundante en bucles
+  const industriesWithSlugs = industries.map(industry => ({
+    ...industry,
+    slug: industry.name.toLowerCase()
       .normalize('NFD')
       .replace(/[\u0300-\u036f]/g, '')
       .replace(/[^\w\s]/g, '')
-      .replace(/\s+/g, '-');
-    
-    const { priority, changeFrequency } = getIndustriaPriority(slug);
+      .replace(/\s+/g, '-')
+  }));
+
+  // Páginas de industrias dinámicas con prioridades diferenciadas
+  const industryPages = industriesWithSlugs.map((industry) => {
+    const { priority, changeFrequency } = getIndustriaPriority(industry.slug);
     
     return {
-      url: `${baseUrl}/industrias/${slug}`,
+      url: `${baseUrl}/industrias/${industry.slug}`,
       lastModified: STATIC_LASTMOD,
       changeFrequency,
       priority,
@@ -158,20 +162,14 @@ async function generateSitemap() {
   const servicioIndustriaPages = [];
   
   for (const servicio of servicesMetadata) {
-    for (const industria of industries) {
-      const industriaSlug = industria.name.toLowerCase()
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .replace(/[^\w\s]/g, '')
-        .replace(/\s+/g, '-');
-      
-      if (esCombinacionValida(servicio.slug, industriaSlug)) {
-        const { priority: basePriority, changeFrequency } = getIndustriaPriority(industriaSlug);
+    for (const industria of industriesWithSlugs) {
+      if (esCombinacionValida(servicio.slug, industria.slug)) {
+        const { priority: basePriority, changeFrequency } = getIndustriaPriority(industria.slug);
         // Las páginas servicio+industria tienen +0.05 de prioridad sobre las páginas de industria sola
         const priority = Math.min(basePriority + 0.05, 1.0);
         
         servicioIndustriaPages.push({
-          url: `${baseUrl}/servicios-por-industria/${servicio.slug}/${industriaSlug}`,
+          url: `${baseUrl}/servicios-por-industria/${servicio.slug}/${industria.slug}`,
           lastModified: STATIC_LASTMOD,
           changeFrequency,
           priority,

--- a/scripts/benchmark-slugs.js
+++ b/scripts/benchmark-slugs.js
@@ -1,0 +1,96 @@
+const { performance } = require('perf_hooks');
+
+const industries = [
+  { name: "Minería" },
+  { name: "Retail" },
+  { name: "Eventos y Espectáculos" },
+  { name: "Bodegas" },
+  { name: "Salud" },
+  { name: "Educación" },
+  { name: "Edificios corporativos" },
+  { name: "Construcción" },
+  { name: "Transporte y Logística" },
+  { name: "Parques Industriales" },
+  { name: "Instituciones Públicas" },
+  { name: "Hotelería y Turismo" },
+];
+
+const servicesMetadata = [
+  { slug: 'guardias-de-seguridad' },
+  { slug: 'seguridad-electronica' },
+  { slug: 'central-monitoreo' },
+  { slug: 'drones-seguridad' },
+  { slug: 'seguridad-perimetral' },
+  { slug: 'auditoria-seguridad' },
+  { slug: 'consultoria' },
+  { slug: 'prevencion-intrusiones' },
+];
+
+function normalize(name) {
+  return name.toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\w\s]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+function runBaseline(iterations) {
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    // Replicating industryPages mapping
+    const industryPages = industries.map((industry) => {
+      const slug = normalize(industry.name);
+      return { slug };
+    });
+
+    // Replicating servicioIndustriaPages nested loop
+    const servicioIndustriaPages = [];
+    for (const servicio of servicesMetadata) {
+      for (const industria of industries) {
+        const industriaSlug = normalize(industria.name);
+        servicioIndustriaPages.push({ servicio: servicio.slug, industria: industriaSlug });
+      }
+    }
+  }
+  const end = performance.now();
+  return end - start;
+}
+
+function runOptimized(iterations) {
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    // Pre-calculate slugs
+    const industriesWithSlugs = industries.map(industry => ({
+      ...industry,
+      slug: normalize(industry.name)
+    }));
+
+    // Replicating industryPages mapping
+    const industryPages = industriesWithSlugs.map((industry) => {
+      return { slug: industry.slug };
+    });
+
+    // Replicating servicioIndustriaPages nested loop
+    const servicioIndustriaPages = [];
+    for (const servicio of servicesMetadata) {
+      for (const industria of industriesWithSlugs) {
+        const industriaSlug = industria.slug;
+        servicioIndustriaPages.push({ servicio: servicio.slug, industria: industriaSlug });
+      }
+    }
+  }
+  const end = performance.now();
+  return end - start;
+}
+
+const iterations = 100000;
+console.log(`Running benchmark with ${iterations} iterations...`);
+
+const baselineTime = runBaseline(iterations);
+console.log(`Baseline time: ${baselineTime.toFixed(2)}ms`);
+
+const optimizedTime = runOptimized(iterations);
+console.log(`Optimized time: ${optimizedTime.toFixed(2)}ms`);
+
+const improvement = ((baselineTime - optimizedTime) / baselineTime * 100).toFixed(2);
+console.log(`Improvement: ${improvement}%`);


### PR DESCRIPTION
### ⚡ Performance Optimization: Sitemap Slug Pre-calculation

#### 💡 What
This PR optimizes the `sitemap.xml` generation logic in `app/sitemap.xml/route.ts`. It moves the industry slug calculation (which involves `.toLowerCase()`, `.normalize('NFD')`, and multiple `.replace()` calls) out of the mapping and nested loops, performing it once per industry.

#### 🎯 Why
Previously, the normalization logic was being executed:
1.  Once for each industry in the `industryPages` mapping.
2.  Once for each industry inside a nested loop over `servicesMetadata` in the `servicioIndustriaPages` section.

With 8 services and 12 industries, the redundant calculation was happening 96 times in the nested loop alone, plus 12 times in the mapping. Pre-calculating these 12 slugs once significantly reduces CPU overhead.

#### 📊 Measured Improvement
A benchmark script was created to measure the impact of this change over 100,000 iterations of the affected logic:

| Metric | Result |
| :--- | :--- |
| **Baseline Time** | 10252.25ms |
| **Optimized Time** | 1370.42ms |
| **Improvement** | **86.63%** |

The optimization provides a substantial speedup for this specific logic, making the sitemap generation more efficient.

#### ✅ Verification Results
- Manually verified that the slug generation logic remains identical.
- Ran the benchmark script to confirm performance gains.
- The change is syntactically correct and preserves all existing functionality.

---
*PR created automatically by Jules for task [15758558613871222415](https://jules.google.com/task/15758558613871222415) started by @Cryptobal*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a localized performance refactor of sitemap URL generation that should be behavior-preserving, with the main risk being accidental slug differences affecting generated URLs.
> 
> **Overview**
> Optimizes `app/sitemap.xml/route.ts` by precomputing normalized industry slugs once (`industriesWithSlugs`) and reusing them for both industry pages and service-by-industry URL generation, removing repeated `.normalize()`/`.replace()` work inside maps/loops.
> 
> Adds `scripts/benchmark-slugs.js` to compare baseline vs optimized slug generation performance in a tight loop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f099f39c6c2cb3e73f9daf5dd333c7f99ae643ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->