### PR TITLE
Add ESLint config and Cursor Cloud dev environment instructions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ The server starts in ~1 second. No env vars are strictly required for local dev 
 ### Lint, typecheck, build
 - **Lint**: `pnpm lint` — the repo has pre-existing ESLint errors (unescaped entities, hooks rules). These are not regressions. The `.eslintrc.json` file (extends `next/core-web-vitals`) is needed for `pnpm lint` to run non-interactively; without it, Next.js prompts for interactive configuration.
 - **Typecheck**: `pnpm typecheck` — runs `tsc --noEmit`. Should pass cleanly.
-- **Build**: `pnpm build` — note that if `.eslintrc.json` is present, the build will fail on the pre-existing lint errors. The production build on Vercel works because it has its own ESLint configuration. To build locally, either remove `.eslintrc.json` before building or add `eslint.ignoreDuringBuilds: true` to `next.config.js`.
+- **Build**: `pnpm build` — `next.config.js` has `eslint.ignoreDuringBuilds: true` so the build skips linting (pre-existing lint errors would otherwise block it).
 - **Tests**: `pnpm test` is a no-op (`echo 'No tests configured yet'`).
 
 ### Key gotchas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,25 @@ You `MUST` always use this tool when:
 + When debugging issues to check for previous solutions
 + Working with unfamiliar parts of the codebase
  of the codebase
+
+## Cursor Cloud specific instructions
+
+### Project overview
+Gard Security (`gard.cl`) — a Next.js 15 (App Router) corporate website for a Chilean B2B private security company. Frontend-only; no database. Blog content is file-based (Markdown in `docs/blog_posts/`). All form submissions go to the external OPAI API (`https://opai.gard.cl`). Images via Cloudflare Images, videos via Cloudflare Stream.
+
+### Running the dev server
+```bash
+pnpm dev --port 3000
+```
+The server starts in ~1 second. No env vars are strictly required for local dev — external services (OPAI, Cloudflare, Google Maps, GTM) degrade gracefully.
+
+### Lint, typecheck, build
+- **Lint**: `pnpm lint` — the repo has pre-existing ESLint errors (unescaped entities, hooks rules). These are not regressions. The `.eslintrc.json` file (extends `next/core-web-vitals`) is needed for `pnpm lint` to run non-interactively; without it, Next.js prompts for interactive configuration.
+- **Typecheck**: `pnpm typecheck` — runs `tsc --noEmit`. Should pass cleanly.
+- **Build**: `pnpm build` — note that if `.eslintrc.json` is present, the build will fail on the pre-existing lint errors. The production build on Vercel works because it has its own ESLint configuration. To build locally, either remove `.eslintrc.json` before building or add `eslint.ignoreDuringBuilds: true` to `next.config.js`.
+- **Tests**: `pnpm test` is a no-op (`echo 'No tests configured yet'`).
+
+### Key gotchas
+- The repo uses **pnpm** (lockfile: `pnpm-lock.yaml`). Do not use npm or yarn.
+- `sharp` and `unrs-resolver` build scripts are ignored by pnpm by default. This is fine for dev; `sharp` is optional for Next.js image optimization in development.
+- Duplicate sitemap warning (`app/sitemap.ts` vs `app/sitemap.xml/route.ts`) appears on startup — this is pre-existing and harmless for development.

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,10 @@
 const nextConfig = {
   reactStrictMode: true,
   // swcMinify removido - es el default en Next.js 15
+
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   
   // Optimización de imágenes
   images: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cambios

- **`.eslintrc.json`** (nuevo): Configuración de ESLint (extiende `next/core-web-vitals`) para que `pnpm lint` funcione de forma no interactiva. Sin este archivo, `next lint` solicita configuración interactiva.
- **`next.config.js`**: Agrega `eslint.ignoreDuringBuilds: true` para que el build no falle por los errores de lint pre-existentes en el código. Esto restaura el comportamiento original del build (antes no había `.eslintrc.json` y Next.js no ejecutaba linting).
- **`AGENTS.md`**: Instrucciones específicas para Cursor Cloud incluyendo:
  - Resumen del proyecto
  - Cómo ejecutar el servidor de desarrollo
  - Comandos de lint, typecheck y build
  - Gotchas conocidos (errores de lint pre-existentes, pnpm vs npm, sharp build scripts, duplicate sitemap warning)

## Verificación

[gard_security_demo_walkthrough.mp4](https://cursor.com/agents/bc-b8e488fd-cbb3-4003-8d16-0de84bb8646c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgard_security_demo_walkthrough.mp4)

Demo del sitio funcionando localmente: navegación por homepage, secciones de servicios y formulario de cotización interactivo.

[Homepage hero section](https://cursor.com/agents/bc-b8e488fd-cbb3-4003-8d16-0de84bb8646c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_hero.webp)
[Formulario de cotización completado](https://cursor.com/agents/bc-b8e488fd-cbb3-4003-8d16-0de84bb8646c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcotizar_form_filled.webp)

### Comandos verificados
- `pnpm install` — dependencias instaladas correctamente
- `pnpm lint` — ejecuta correctamente (errores pre-existentes en el código)
- `pnpm typecheck` — pasa sin errores
- `pnpm build` — compila correctamente con `ignoreDuringBuilds: true`
- `pnpm dev --port 3000` — servidor funcional, responde HTTP 200

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8e488fd-cbb3-4003-8d16-0de84bb8646c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8e488fd-cbb3-4003-8d16-0de84bb8646c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

