### PR TITLE
fix(ci): reparar workflow usando pnpm y lockfile correcto

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -20,32 +20,38 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
-        run: npm run lint
+        run: pnpm run lint
 
       - name: Type check
-        run: npm run typecheck || true
+        run: pnpm run typecheck || true
 
       - name: Build
-        run: npm run build
+        run: pnpm run build
 
       - name: Test
-        run: npm run test || true
+        run: pnpm run test || true
 
       - name: Cache Next.js build
         uses: actions/cache@v3
         with:
           path: |
             .next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}- 
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}- 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen
Fix mínimo al workflow de CI para corregir fallo reproducible en PRs recientes: se estaba usando `npm` en un repo que solo tiene `pnpm-lock.yaml`.

## Bug reproducido (antes)
- `npm ci` falla localmente sin `package-lock.json`.
- Logs de GitHub Actions fallan en `setup-node` por lockfile inexistente para npm.

## Cambios
- En `.github/workflows/nextjs.yml`:
  - Instala pnpm con `pnpm/action-setup@v4` y `version: 10`.
  - Cambia cache de `setup-node` a `pnpm` con `cache-dependency-path: pnpm-lock.yaml`.
  - Cambia instalación a `pnpm install --frozen-lockfile`.
  - Cambia ejecución de scripts de `npm run ...` a `pnpm run ...`.
  - Actualiza claves de cache de Next.js para usar `pnpm-lock.yaml`.

## Validación
- Repro del bug original: `npm ci` falla como en CI.
- Repro adicional de riesgo en PR #5: `pnpm@8` + lockfile v9 falla con `--frozen-lockfile`.
- Post-fix: `pnpm install --frozen-lockfile` funciona correctamente en este repo.

## Notas sobre otros bugs de alta confianza detectados (sin tocar en este PR)
- `pnpm run lint` falla en CI no interactivo por falta de `.eslintrc.json`.
- Al agregar `.eslintrc.json`, aparecen errores de lint preexistentes que también rompen `build` si lint está habilitado durante build.

Este PR se mantiene intencionalmente pequeño y enfocado solo en el bug principal de lockfile/gestor de paquetes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-613de550-e571-470a-9233-4ba83c6fbf88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-613de550-e571-470a-9233-4ba83c6fbf88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

