### PR TITLE
Seo/fase 2 schemas internal linking

### DIFF
--- a/app/[ciudad]/[servicio]/components/CiudadServicioLanding.tsx
+++ b/app/[ciudad]/[servicio]/components/CiudadServicioLanding.tsx
@@ -26,6 +26,8 @@ import CloudflareImage from '@/components/CloudflareImage';
 import ClientesCarrusel from '@/components/ClientesCarrusel';
 import { cn } from '@/lib/utils';
 import { Stream } from '@cloudflare/stream-react';
+import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema';
+import ServiceSchema from '@/components/seo/ServiceSchema';
 
 // Mapeo de servicios a ID de videos de Cloudflare Stream
 const videosPorServicio = {
@@ -303,13 +305,32 @@ export default function CiudadServicioLanding({ content, params }: CiudadServici
   // Obtenemos el nombre formateado de la ciudad y el servicio
   const ciudadFormatted = params.ciudad.replace(/-/g, ' ');
   const servicioFormatted = params.servicio.replace(/-/g, ' ');
-  
+
   // Obtener el ID del video para el servicio actual con fallback al video genérico "Escudo Seguridad"
   const defaultVideoId = "ac93b4a10e87873748171425b9f8066d";
   const videoId = videosPorServicio[params.servicio as keyof typeof videosPorServicio] || defaultVideoId;
 
+  // Schemas SEO: BreadcrumbList + Service con areaServed por ciudad
+  const BASE_URL = 'https://www.gard.cl';
+  const canonicalUrl = `${BASE_URL}/${params.ciudad}/${params.servicio}`;
+  const ciudadCapitalizada = ciudadFormatted.replace(/\b\w/g, (c) => c.toUpperCase());
+  const breadcrumbItems = [
+    { name: 'Inicio', url: BASE_URL },
+    { name: 'Servicios', url: `${BASE_URL}/servicios` },
+    { name: content.h1, url: canonicalUrl },
+  ];
+
   return (
     <LazyMotion features={domAnimation}>
+      <BreadcrumbSchema items={breadcrumbItems} />
+      <ServiceSchema
+        name={content.h1}
+        description={content.metaDescription}
+        serviceType="Seguridad Privada"
+        category="Seguridad Privada"
+        url={canonicalUrl}
+        areaServed={[{ type: 'City', name: ciudadCapitalizada }]}
+      />
       <div className="flex flex-col min-h-screen relative">
         {/* CTA Flotante en móvil (solo aparece al hacer scroll) */}
         <AnimatePresence>

--- a/app/[ciudad]/[servicio]/page.tsx
+++ b/app/[ciudad]/[servicio]/page.tsx
@@ -41,15 +41,19 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     };
   }
   
+  const canonicalUrl = `https://www.gard.cl/${resolvedParams.ciudad}/${resolvedParams.servicio}`;
   return {
     title: content.title,
     description: content.metaDescription,
+    alternates: {
+      canonical: canonicalUrl,
+    },
     openGraph: {
       title: content.title,
       description: content.metaDescription,
       type: 'website',
       locale: 'es_CL',
-        url: `https://www.gard.cl/${resolvedParams.ciudad}/${resolvedParams.servicio}`,
+      url: canonicalUrl,
       siteName: 'Gard Security',
     },
   };

--- a/app/ciudades/page.tsx
+++ b/app/ciudades/page.tsx
@@ -1,72 +1,78 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import React from 'react';
 import Link from 'next/link';
-import { ciudades, getAllCiudades, getCiudadesByRegion, CiudadData } from '@/lib/data/ciudad-data';
+import { getAllCiudades, CiudadData } from '@/lib/data/ciudad-data';
 import { servicesMetadata } from '../servicios/serviceMetadata';
-import { 
-  MapPin, 
-  X, 
-  ChevronDown, 
-  ChevronRight, 
-  Users, 
-  Building, 
-  Shield, 
-  Calendar, 
-  Search, 
-  HelpCircle, 
-  ArrowRight, 
-  Phone,
-  Home
-} from 'lucide-react';
-import CloudflareImage from '@/components/CloudflareImage';
-import { cloudflareImages } from '@/lib/images';
+import { MapPin } from 'lucide-react';
+import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema';
 
-// Definimos los tipos
+const BASE_URL = 'https://www.gard.cl';
+
 interface Ciudad extends CiudadData {}
 
-// Versión simplificada para permitir la compilación
 export default function CiudadesPage() {
-  const [regionSeleccionada, setRegionSeleccionada] = useState<string | null>(null);
-  const [ciudadSeleccionada, setCiudadSeleccionada] = useState<Ciudad | null>(null);
-  
-  // Función para agrupar ciudades por región
-  const agruparCiudadesPorRegion = () => {
-    return getCiudadesByRegion();
-  };
-  
+  const ciudades = getAllCiudades();
+
   return (
     <>
-      <div className="py-16">
-        <div className="max-w-7xl mx-auto px-4">
-          <h1 className="text-3xl font-bold mb-8">Cobertura Nacional de Seguridad Privada</h1>
-          <p className="text-xl text-muted-foreground dark:text-gray-300 mb-4">
-            Gard Security opera en 10 ciudades de Chile con guardias certificados OS10, monitoreo 24/7 y soluciones adaptadas a cada región. Cotiza servicios de seguridad en tu ciudad.
-          </p>
-          <p className="text-base text-muted-foreground dark:text-gray-400 mb-8">
-            Santiago, Antofagasta, Valparaíso, Concepción, Iquique, Puerto Montt, Rancagua, Chillán, Temuco y Viña del Mar.
-          </p>
-          <div className="mt-8 grid md:grid-cols-3 gap-6">
-            {getAllCiudades().map((ciudad) => (
-              <Link 
+      <BreadcrumbSchema
+        items={[
+          { name: 'Inicio', url: BASE_URL },
+          { name: 'Cobertura por Ciudad', url: `${BASE_URL}/ciudades` },
+        ]}
+      />
+
+      <section className="gard-section bg-white dark:bg-gray-900">
+        <div className="gard-container max-w-7xl mx-auto px-4">
+          <div className="max-w-4xl">
+            <h1 className="text-3xl md:text-4xl font-bold mb-6 font-title">
+              Cobertura de Guardias de Seguridad en Chile
+            </h1>
+            <p className="text-xl text-muted-foreground dark:text-gray-300 mb-4">
+              Gard Security opera con guardias certificados OS10 en 10 ciudades de Chile: Santiago, Antofagasta, Valparaíso, Concepción, Iquique, Puerto Montt, Rancagua, Chillán, Temuco y Viña del Mar.
+            </p>
+            <p className="text-base text-muted-foreground dark:text-gray-400 mb-12">
+              Selecciona tu ciudad para ver los servicios disponibles.
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {ciudades.map((ciudad: Ciudad) => (
+              <article
                 key={ciudad.slug}
-                href={`/ciudades/${ciudad.slug}`}
-                className="p-6 bg-white dark:bg-gray-800 rounded-xl shadow-sm hover:shadow-md transition-all"
+                className="p-6 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-sm hover:shadow-md transition-all"
               >
-                <h2 className="text-xl font-medium mb-2">{ciudad.nombre}</h2>
-                <div className="flex items-center text-gray-500 mb-4">
-                  <MapPin size={16} className="mr-1" />
-                  <span>{ciudad.region}</span>
+                <div className="flex items-center gap-2 mb-2">
+                  <MapPin size={18} className="text-primary" />
+                  <h2 className="text-xl font-semibold">{ciudad.nombre}</h2>
                 </div>
-                <p className="text-gray-600 dark:text-gray-300 line-clamp-2">
-                  {ciudad.descripcion.substring(0, 120)}...
+                <div className="text-sm text-gray-500 dark:text-gray-400 mb-3">{ciudad.region}</div>
+                <p className="text-sm text-gray-600 dark:text-gray-300 mb-4 line-clamp-3">
+                  {ciudad.descripcion}
                 </p>
-              </Link>
+                <div>
+                  <div className="text-xs font-semibold text-primary uppercase tracking-wide mb-2">
+                    Servicios disponibles
+                  </div>
+                  <ul className="space-y-1">
+                    {servicesMetadata.map((servicio) => (
+                      <li key={servicio.slug}>
+                        <Link
+                          href={`/${ciudad.slug}/${servicio.slug}`}
+                          className="text-sm text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors"
+                        >
+                          {servicio.title.split('|')[0].trim()} en {ciudad.nombre}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </article>
             ))}
           </div>
         </div>
-      </div>
+      </section>
     </>
   );
-} 
+}

--- a/app/components/blog/BlogPost.tsx
+++ b/app/components/blog/BlogPost.tsx
@@ -193,22 +193,30 @@ export default function BlogPost({ slug }: { slug: string }) {
       }
     : {
         '@context': 'https://schema.org',
-        '@type': 'BlogPosting',
+        '@type': 'Article',
         headline: post.title,
         description: post.description,
-        image: getBlogPostShareImageUrl(post.cardImage, post.imageId),
+        image: [getBlogPostShareImageUrl(post.cardImage, post.imageId)],
         datePublished: post.date,
+        dateModified: post.date,
         author: {
           '@type': 'Organization',
           name: post.author || 'Gard Security',
+          url: 'https://www.gard.cl',
         },
         publisher: {
           '@type': 'Organization',
+          '@id': 'https://www.gard.cl/#organization',
           name: 'Gard Security',
+          url: 'https://www.gard.cl',
           logo: {
             '@type': 'ImageObject',
             url: `https://imagedelivery.net/${CLOUDFLARE_ACCOUNT_HASH}/7661cf51-c66b-4419-9229-e6e50f76ff00/public`,
           },
+        },
+        mainEntityOfPage: {
+          '@type': 'WebPage',
+          '@id': `https://www.gard.cl/blog/${slug}`,
         },
       };
 

--- a/app/servicios-por-industria/[servicio]/[industria]/components/ServicioIndustriaLanding.tsx
+++ b/app/servicios-por-industria/[servicio]/[industria]/components/ServicioIndustriaLanding.tsx
@@ -29,6 +29,7 @@ import CloudflareImage from '@/components/CloudflareImage';
 import ClientesCarrusel from '@/components/ClientesCarrusel';
 import { cn } from '@/lib/utils';
 import { Stream } from '@cloudflare/stream-react';
+import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema';
 
 interface ServicioIndustriaLandingProps {
   content: ServicioIndustriaContent;
@@ -291,13 +292,23 @@ export default function ServicioIndustriaLanding({ content, params }: ServicioIn
   // Obtenemos el nombre formateado del servicio y la industria
   const servicioFormatted = params.servicio.replace(/-/g, ' ');
   const industriaFormatted = params.industria.replace(/-/g, ' ');
-  
+
   // Obtener el ID del video con fallback al video genérico
   const defaultVideoId = "ac93b4a10e87873748171425b9f8066d";
   const videoId = content.videoId || defaultVideoId;
 
+  // Schema SEO: BreadcrumbList derivado de params
+  const BASE_URL = 'https://www.gard.cl';
+  const canonicalUrl = `${BASE_URL}/servicios-por-industria/${params.servicio}/${params.industria}`;
+  const breadcrumbItems = [
+    { name: 'Inicio', url: BASE_URL },
+    { name: 'Servicios', url: `${BASE_URL}/servicios` },
+    { name: content.h1 || 'Servicio por Industria', url: canonicalUrl },
+  ];
+
   return (
     <LazyMotion features={domAnimation}>
+      <BreadcrumbSchema items={breadcrumbItems} />
       <div className="flex flex-col min-h-screen relative">
         {/* CTA Flotante en móvil (solo aparece al hacer scroll) */}
         <AnimatePresence>

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -99,6 +99,7 @@ async function generateSitemap() {
     { route: '', priority: 1.0, changeFreq: 'weekly' as const },
     { route: '/servicios', priority: 0.9, changeFreq: 'weekly' as const },
     { route: '/industrias', priority: 0.9, changeFreq: 'weekly' as const },
+    { route: '/ciudades', priority: 0.85, changeFreq: 'monthly' as const },
     { route: '/cotizar', priority: 0.95, changeFreq: 'weekly' as const }, // Página de conversión
     { route: '/sobre-nosotros', priority: 0.8, changeFreq: 'monthly' as const },
     { route: '/tecnologia-seguridad', priority: 0.75, changeFreq: 'monthly' as const },

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -385,6 +385,53 @@ export default function Footer() {
           </div>
         </div>
 
+        {/* Cobertura por Ciudad: 10 ciudades × top 3 servicios = 30 enlaces SEO */}
+        <section className="border-t border-gray-200 dark:border-white/10 mt-10 pt-8">
+          <h3 className="font-semibold text-primary dark:text-white text-lg mb-6">
+            Cobertura de Seguridad por Ciudad
+          </h3>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-x-6 gap-y-2 text-sm">
+            <li><Link href="/santiago/guardias-de-seguridad" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Guardias Santiago</Link></li>
+            <li><Link href="/santiago/seguridad-electronica" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Seguridad Electrónica Santiago</Link></li>
+            <li><Link href="/santiago/central-monitoreo" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Monitoreo Santiago</Link></li>
+            <li><Link href="/antofagasta/guardias-de-seguridad" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Guardias Antofagasta</Link></li>
+            <li><Link href="/antofagasta/seguridad-electronica" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Seguridad Electrónica Antofagasta</Link></li>
+            <li><Link href="/antofagasta/central-monitoreo" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Monitoreo Antofagasta</Link></li>
+            <li><Link href="/valparaiso/guardias-de-seguridad" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Guardias Valparaíso</Link></li>
+            <li><Link href="/valparaiso/seguridad-electronica" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Seguridad Electrónica Valparaíso</Link></li>
+            <li><Link href="/valparaiso/central-monitoreo" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Monitoreo Valparaíso</Link></li>
+            <li><Link href="/concepcion/guardias-de-seguridad" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Guardias Concepción</Link></li>
+            <li><Link href="/concepcion/seguridad-electronica" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Seguridad Electrónica Concepción</Link></li>
+            <li><Link href="/concepcion/central-monitoreo" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Monitoreo Concepción</Link></li>
+            <li><Link href="/iquique/guardias-de-seguridad" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Guardias Iquique</Link></li>
+            <li><Link href="/iquique/seguridad-electronica" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Seguridad Electrónica Iquique</Link></li>
+            <li><Link href="/iquique/central-monitoreo" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Monitoreo Iquique</Link></li>
+            <li><Link href="/puerto-montt/guardias-de-seguridad" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Guardias Puerto Montt</Link></li>
+            <li><Link href="/puerto-montt/seguridad-electronica" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Seguridad Electrónica Puerto Montt</Link></li>
+            <li><Link href="/puerto-montt/central-monitoreo" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Monitoreo Puerto Montt</Link></li>
+            <li><Link href="/rancagua/guardias-de-seguridad" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Guardias Rancagua</Link></li>
+            <li><Link href="/rancagua/seguridad-electronica" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Seguridad Electrónica Rancagua</Link></li>
+            <li><Link href="/rancagua/central-monitoreo" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Monitoreo Rancagua</Link></li>
+            <li><Link href="/chillan/guardias-de-seguridad" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Guardias Chillán</Link></li>
+            <li><Link href="/chillan/seguridad-electronica" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Seguridad Electrónica Chillán</Link></li>
+            <li><Link href="/chillan/central-monitoreo" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Monitoreo Chillán</Link></li>
+            <li><Link href="/temuco/guardias-de-seguridad" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Guardias Temuco</Link></li>
+            <li><Link href="/temuco/seguridad-electronica" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Seguridad Electrónica Temuco</Link></li>
+            <li><Link href="/temuco/central-monitoreo" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Monitoreo Temuco</Link></li>
+            <li><Link href="/vina-del-mar/guardias-de-seguridad" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Guardias Viña del Mar</Link></li>
+            <li><Link href="/vina-del-mar/seguridad-electronica" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Seguridad Electrónica Viña del Mar</Link></li>
+            <li><Link href="/vina-del-mar/central-monitoreo" className="text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors">Monitoreo Viña del Mar</Link></li>
+          </ul>
+          <div className="mt-6">
+            <Link
+              href="/ciudades"
+              className="text-sm font-medium text-primary dark:text-accent hover:underline inline-flex items-center gap-1"
+            >
+              Ver todas las ciudades y servicios →
+            </Link>
+          </div>
+        </section>
+
         <div className="border-t border-gray-200 dark:border-white/10 mt-10 pt-6 text-center">
           <p className="text-gray-700 dark:text-blue-100/80 text-sm md:text-base" itemProp="name">
             © {currentYear} Gard Security. Todos los derechos reservados.
@@ -393,4 +440,4 @@ export default function Footer() {
       </div>
     </footer>
   );
-} 
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly adds SEO metadata and internal links with limited impact on runtime logic; main risk is unintended layout/link changes or incorrect canonical/schema URLs affecting indexing.
> 
> **Overview**
> Improves SEO for city/service and industry/service landing pages by adding JSON-LD `BreadcrumbSchema` and (for `/{ciudad}/{servicio}`) `ServiceSchema` with city-based `areaServed`.
> 
> Adds canonical URL support to the dynamic `/{ciudad}/{servicio}` metadata, expands the `/ciudades` page into a city-to-services hub with breadcrumb schema and per-city service links, and includes `/ciudades` in the sitemap.
> 
> Refines blog structured data by standardizing non-OPAI posts to an `Article` schema (array `image`, `dateModified`, `publisher` `@id`, and `mainEntityOfPage`). Also adds a footer section with 30 hardcoded city→top-service links plus a link to `/ciudades` to strengthen internal linking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 261b3ef1dfd7cdbc67416518a6fc9b1d84f595a0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->