### PR TITLE
fix(seo): response time integrity (30 min real) + remove residual fake reviews

### DIFF
--- a/app/[ciudad]/[servicio]/components/CiudadServicioLanding.tsx
+++ b/app/[ciudad]/[servicio]/components/CiudadServicioLanding.tsx
@@ -648,10 +648,10 @@ export default function CiudadServicioLanding({ content, params }: CiudadServici
           <div className="gard-container">
             <div className="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8">
               {[
-                { value: "+500", label: "Clientes Satisfechos" },
+                { value: "23", label: "Clientes B2B activos" },
                 { value: "24/7", label: "Servicio Continuo" },
-                { value: "15 min", label: "Tiempo de Respuesta" },
-                { value: "100%", label: "Personal Certificado" }
+                { value: "30 min", label: "Respuesta promedio (zona urbana)" },
+                { value: "100%", label: "Personal Certificado OS10" }
               ].map((stat, index) => (
                 <motion.div 
                   key={index}

--- a/app/empresa-guardias-seguridad-chile/page.tsx
+++ b/app/empresa-guardias-seguridad-chile/page.tsx
@@ -13,7 +13,7 @@ import { companyStats } from '@/lib/data/company-stats';
 export const metadata: Metadata = {
   title: 'Empresa de Guardias de Seguridad en Chile | Gard Security #1',
   description:
-    'Gard Security es la empresa líder de guardias de seguridad en Chile: 4.9/5 rating, 100% guardias OS10, cobertura nacional y tiempos de respuesta <15 min. Cotiza guardias para tu empresa.',
+    'Gard Security es la empresa líder de guardias de seguridad en Chile: 4.9/5 rating, 100% guardias OS10, cobertura nacional y central de monitoreo 24/7. Cotiza guardias para tu empresa.',
   keywords: [
     'empresa de guardias de seguridad',
     'guardias de seguridad chile',
@@ -31,7 +31,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: 'Empresa de Guardias de Seguridad en Chile | Gard Security #1',
-    description: `Guardias OS10, ${companyStats.citiesCovered} ciudades, equipo fundador con ${companyStats.leadershipYearsExperience}+ años de experiencia, 4.9/5 rating, continuidad 99.9%, respuesta <15 min. Gard Security es #1 en guardias para empresas en Chile.`,
+    description: `Guardias OS10, ${companyStats.citiesCovered} ciudades, equipo fundador con ${companyStats.leadershipYearsExperience}+ años de experiencia, 4.9/5 rating, continuidad ${companyStats.operationalContinuityPct}% y central 24/7. Gard Security es #1 en guardias para empresas en Chile.`,
     url: 'https://www.gard.cl/empresa-guardias-seguridad-chile',
     siteName: 'Gard Security',
     locale: 'es_CL',
@@ -69,8 +69,7 @@ const faqs = [
   },
   {
     question: '¿Cuál es el tiempo de respuesta ante incidentes?',
-    answer:
-      'Menos de 15 minutos en zonas urbanas. Protocolos escalables y central de monitoreo 24/7 para alertas y coordinación.',
+    answer: `Tiempo de respuesta promedio ${companyStats.avgIncidentResponseMinutesSantiago} minutos en zona urbana de Santiago (medido sobre contratos activos). Protocolos escalables y central de monitoreo 24/7 para alertas y coordinación con carabineros, bomberos y ambulancia.`,
   },
   {
     question: '¿Cuánto cuesta un guardia de seguridad en Santiago?',
@@ -103,40 +102,12 @@ const faqs = [
   },
   {
     question: '¿Qué diferencia a Gard Security de otras empresas?',
-    answer: `Especialización B2B exclusiva, 100% OS10 auditado, continuidad 99.9%, respuesta <15 min y cobertura en ${companyStats.citiesCovered} ciudades. Tenemos cobertura en todo Chile.`,
+    answer: `Especialización B2B exclusiva, 100% OS10 auditado, continuidad ${companyStats.operationalContinuityPct}%, tiempo de respuesta promedio ${companyStats.avgIncidentResponseMinutesSantiago} min en zona urbana y cobertura en ${companyStats.citiesCovered} ciudades. Tenemos cobertura en todo Chile.`,
   },
 ];
 
-const reviews: Array<{
-  author: { name: string; type: 'Person' | 'Organization' };
-  datePublished: string;
-  ratingValue: number;
-  reviewBody: string;
-  name: string;
-}> = [
-  {
-    author: { name: 'Gerente de Seguridad Corporativa', type: 'Person' as const },
-    datePublished: '2025-05-20',
-    ratingValue: 5,
-    reviewBody:
-      'Excelente despliegue en edificios clase A: guardias OS10, bilingües y con respuesta <15 min. Continuidad 99.9% en 12 meses.',
-    name: 'Edificios corporativos clase A',
-  },
-  {
-    author: { name: 'Jefe de Logística', type: 'Person' as const },
-    datePublished: '2025-04-30',
-    ratingValue: 5,
-    reviewBody: 'Reducción de mermas -80% en 6 meses. Guardias atentos, control de accesos y CCTV con analítica.',
-    name: 'Logística y bodegas',
-  },
-  {
-    author: { name: 'Administrador de Condominio Comercial', type: 'Person' as const },
-    datePublished: '2025-04-05',
-    ratingValue: 5,
-    reviewBody: 'Guardias profesionales, informes claros y supervisión permanente. Respuesta rápida ante incidencias.',
-    name: 'Complejo comercial',
-  },
-];
+// Reviews hardcoded inventados (Fase 1.3 residual) removidos. El
+// ReviewSchema mantiene aggregateRating verificable en GMB.
 
 export default function EmpresaGuardiasSeguridadPage() {
   return (
@@ -159,8 +130,7 @@ export default function EmpresaGuardiasSeguridadPage() {
           description: 'Guardias de seguridad OS10 con cobertura nacional y monitoreo 24/7.',
         }}
         aggregateRating={{ ratingValue: 4.9, reviewCount: 57, bestRating: 5, worstRating: 1 }}
-        reviews={reviews}
-        verificationUrl="https://maps.app.goo.gl/ywW2rQEWu4g4xxxy8"
+        verificationUrl={companyStats.gmbShortUrl}
       />
       <Breadcrumbs items={breadcrumbs} />
 
@@ -215,8 +185,8 @@ export default function EmpresaGuardiasSeguridadPage() {
             </div>
             <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl p-6">
               <Timer className="h-10 w-10 text-primary mb-3" />
-              <h3 className="text-white font-semibold text-lg mb-2">Respuesta &lt;15 Min</h3>
-              <p className="text-white/80 text-sm">Central 24/7 y protocolos express para incidentes y nuevas activaciones.</p>
+              <h3 className="text-white font-semibold text-lg mb-2">Respuesta {companyStats.avgIncidentResponseMinutesSantiago} Min Promedio</h3>
+              <p className="text-white/80 text-sm">Zona urbana Santiago. Central 24/7 y protocolos express para incidentes y nuevas activaciones.</p>
             </div>
             <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl p-6">
               <Users className="h-10 w-10 text-primary mb-3" />
@@ -255,7 +225,7 @@ export default function EmpresaGuardiasSeguridadPage() {
               <CheckCircle className="h-8 w-8 text-primary flex-shrink-0" />
               <div>
                 <h3 className="text-xl font-semibold mb-2">KPIs Transparentes</h3>
-                <p className="text-muted-foreground">Reportes mensuales, tiempos de respuesta &lt;15 min y cumplimiento contractual auditado.</p>
+                <p className="text-muted-foreground">Reportes mensuales, tiempo de respuesta promedio {companyStats.avgIncidentResponseMinutesSantiago} min en zona urbana y cumplimiento contractual auditado.</p>
               </div>
             </div>
             <div className="flex gap-4">
@@ -317,8 +287,8 @@ export default function EmpresaGuardiasSeguridadPage() {
                   <td className="px-6 py-4 text-center text-muted-foreground">95-97%</td>
                 </tr>
                 <tr className="border-b">
-                  <td className="px-6 py-4 font-medium">Tiempo de respuesta</td>
-                  <td className="px-6 py-4 text-center text-green-600 font-bold">&lt;15 min</td>
+                  <td className="px-6 py-4 font-medium">Tiempo de respuesta (zona urbana)</td>
+                  <td className="px-6 py-4 text-center text-green-600 font-bold">{companyStats.avgIncidentResponseMinutesSantiago} min</td>
                   <td className="px-6 py-4 text-center text-muted-foreground">30-45 min</td>
                 </tr>
               </tbody>

--- a/app/empresa-seguridad-privada-chile/page.tsx
+++ b/app/empresa-seguridad-privada-chile/page.tsx
@@ -68,12 +68,11 @@ const faqs = [
   },
   {
     question: '¿Cuál es el tiempo de respuesta ante incidentes?',
-    answer:
-      'Menos de 15 minutos en Santiago y centros urbanos; protocolos express en 48h para activación en nuevas instalaciones; continuidad operacional 99.9% anual.',
+    answer: `Tiempo de respuesta promedio ${companyStats.avgIncidentResponseMinutesSantiago} minutos en Santiago zona urbana, medido sobre contratos activos. Protocolos express en 48h para activación en nuevas instalaciones; continuidad operacional ${companyStats.operationalContinuityPct}% anual.`,
   },
   {
     question: '¿Qué diferencia a Gard Security de otras empresas?',
-    answer: `Especialización B2B exclusiva, 100% OS10 auditado, reducción de mermas hasta 85% en logística, rating 4.9/5 y monitoreo 24/7 con respuesta <15 min. Cobertura en ${companyStats.citiesCovered} ciudades. Tenemos cobertura en todo Chile.`,
+    answer: `Especialización B2B exclusiva, 100% OS10 auditado, reducción de mermas hasta 85% en logística, rating 4.9/5 y monitoreo 24/7 con tiempo de respuesta promedio ${companyStats.avgIncidentResponseMinutesSantiago} min en zona urbana. Cobertura en ${companyStats.citiesCovered} ciudades. Tenemos cobertura en todo Chile.`,
   },
   {
     question: '¿Operan en regiones fuera de Santiago?',
@@ -91,43 +90,12 @@ const faqs = [
   },
   {
     question: '¿Cómo miden resultados y desempeño?',
-    answer:
-      'KPIs operativos auditables: continuidad 99.9%, tiempo de respuesta <15 min, reducción de mermas hasta 85% en logística, cumplimiento OS10 100%, reportes mensuales.',
+    answer: `KPIs operativos auditables: continuidad ${companyStats.operationalContinuityPct}%, tiempo de respuesta promedio ${companyStats.avgIncidentResponseMinutesSantiago} min en zona urbana, reducción de mermas hasta 85% en logística, cumplimiento OS10 100%, reportes mensuales.`,
   },
 ];
 
-const reviews: Array<{
-  author: { name: string; type: 'Person' | 'Organization' };
-  datePublished: string;
-  ratingValue: number;
-  reviewBody: string;
-  name: string;
-}> = [
-  {
-    author: { name: 'Gerente de Operaciones Mineras', type: 'Person' as const },
-    datePublished: '2025-06-01',
-    ratingValue: 5,
-    reviewBody:
-      'Gard Security redujo incidentes en faena minera en 70% con guardias OS10 auditados y protocolos en zonas remotas. Tiempos de respuesta consistentes <15 min.',
-    name: 'Resultados en minería',
-  },
-  {
-    author: { name: 'Director de Logística Retail', type: 'Person' as const },
-    datePublished: '2025-05-15',
-    ratingValue: 5,
-    reviewBody:
-      'Disminuimos mermas en CD principal en -85% con control de accesos y CCTV con analítica. Equipo 24/7 y reportes mensuales claros.',
-    name: 'Logística con reducción de mermas',
-  },
-  {
-    author: { name: 'Administrador de Edificio Corporativo', type: 'Person' as const },
-    datePublished: '2025-04-10',
-    ratingValue: 5,
-    reviewBody:
-      'Excelente servicio en edificio clase A: guardias bilingües, recepción ejecutiva y protocolos de evacuación probados. Rating interno 4.9/5.',
-    name: 'Seguridad corporativa premium',
-  },
-];
+// Reviews hardcoded inventados (Fase 1.3 residual) removidos. El
+// ReviewSchema mantiene aggregateRating verificable en GMB.
 
 export default function EmpresaSeguridadPrivadaPage() {
   return (
@@ -150,8 +118,7 @@ export default function EmpresaSeguridadPrivadaPage() {
           description: `Seguridad privada B2B con 100% guardias OS10, ${companyStats.citiesCovered} ciudades y monitoreo 24/7.`,
         }}
         aggregateRating={{ ratingValue: 4.9, reviewCount: 57, bestRating: 5, worstRating: 1 }}
-        reviews={reviews}
-        verificationUrl="https://maps.app.goo.gl/ywW2rQEWu4g4xxxy8"
+        verificationUrl={companyStats.gmbShortUrl}
       />
       <Breadcrumbs items={breadcrumbs} />
 
@@ -211,8 +178,8 @@ export default function EmpresaSeguridadPrivadaPage() {
             </div>
             <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl p-6">
               <Clock className="h-10 w-10 text-primary mb-3" />
-              <h3 className="text-white font-semibold text-lg mb-2">Respuesta &lt;15 Min</h3>
-              <p className="text-white/80 text-sm">Monitoreo 24/7 y protocolos express con continuidad operacional 99.9%.</p>
+              <h3 className="text-white font-semibold text-lg mb-2">Respuesta {companyStats.avgIncidentResponseMinutesSantiago} Min Promedio</h3>
+              <p className="text-white/80 text-sm">Zona urbana Santiago. Monitoreo 24/7 y protocolos express con continuidad operacional {companyStats.operationalContinuityPct}%.</p>
             </div>
           </div>
         </div>
@@ -248,7 +215,7 @@ export default function EmpresaSeguridadPrivadaPage() {
               <CheckCircle className="h-8 w-8 text-primary flex-shrink-0" />
               <div>
                 <h3 className="text-xl font-semibold mb-2">Resultados Medibles</h3>
-                <p className="text-muted-foreground">Reducción de mermas hasta 85% en logística y tiempos de respuesta &lt;15 min en corporativo.</p>
+                <p className="text-muted-foreground">Reducción de mermas hasta 85% en logística y tiempo de respuesta promedio {companyStats.avgIncidentResponseMinutesSantiago} min en zona urbana.</p>
               </div>
             </div>
             <div className="flex gap-4">
@@ -317,8 +284,8 @@ export default function EmpresaSeguridadPrivadaPage() {
                   <td className="px-6 py-4 text-center text-muted-foreground">3-5</td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 font-medium">Tiempo de respuesta</td>
-                  <td className="px-6 py-4 text-center text-green-600 font-bold">&lt;15 min</td>
+                  <td className="px-6 py-4 font-medium">Tiempo de respuesta (zona urbana)</td>
+                  <td className="px-6 py-4 text-center text-green-600 font-bold">{companyStats.avgIncidentResponseMinutesSantiago} min</td>
                   <td className="px-6 py-4 text-center text-muted-foreground">30-45 min</td>
                 </tr>
               </tbody>

--- a/app/guardias-de-seguridad-privada-para-empresas/page.tsx
+++ b/app/guardias-de-seguridad-privada-para-empresas/page.tsx
@@ -63,11 +63,10 @@ const faqItems: FAQItem[] = [
   },
   {
     question: '¿Qué tiempo de respuesta ofrecen ante incidentes?',
-    answerText:
-      'Nuestros guardias en el sitio tienen protocolos de reacción inmediata (menos de 2 minutos para activar alertas y coordinación). Para refuerzos móviles desde nuestra central, el tiempo de respuesta promedio en la Región Metropolitana es inferior a 15 minutos. Contamos con central de monitoreo 24/7 que coordina con Carabineros, bomberos y ambulancia cuando la situación lo requiere.',
+    answerText: `Nuestros guardias en el sitio tienen protocolos de reacción inmediata (menos de 2 minutos para activar alertas y coordinación). Para refuerzos móviles desde nuestra central, el tiempo de respuesta promedio en la Región Metropolitana es de ${companyStats.avgIncidentResponseMinutesSantiago} minutos, medido sobre contratos activos. Contamos con central de monitoreo 24/7 que coordina con Carabineros, bomberos y ambulancia cuando la situación lo requiere.`,
     answerNode: (
       <p>
-        Nuestros guardias en el sitio tienen protocolos de reacción inmediata (menos de 2 minutos para activar alertas y coordinación). Para refuerzos móviles desde nuestra central, el tiempo de respuesta promedio en la Región Metropolitana es inferior a 15 minutos. Contamos con central de monitoreo 24/7 que coordina con Carabineros, bomberos y ambulancia cuando la situación lo requiere.
+        Nuestros guardias en el sitio tienen protocolos de reacción inmediata (menos de 2 minutos para activar alertas y coordinación). Para refuerzos móviles desde nuestra central, el tiempo de respuesta promedio en la Región Metropolitana es de {companyStats.avgIncidentResponseMinutesSantiago} minutos, medido sobre contratos activos. Contamos con central de monitoreo 24/7 que coordina con Carabineros, bomberos y ambulancia cuando la situación lo requiere.
       </p>
     ),
   },
@@ -331,7 +330,7 @@ export default function GuardiasParaEmpresasPage() {
                   ['Certificación OS10', '100% del personal auditada', '70-85% real en mercado'],
                   ['Supervisión digital en tiempo real', 'Sistema OPAI propio con IA', 'Planillas o apps básicas'],
                   ['Cobertura geográfica', '10 ciudades de Chile', 'Santiago o ciudad sede'],
-                  ['Tiempo de respuesta móvil', 'Menor a 15 min en RM', 'Variable, sin SLA'],
+                  ['Tiempo de respuesta móvil (RM)', `Promedio ${companyStats.avgIncidentResponseMinutesSantiago} min en zona urbana`, 'Variable, sin SLA'],
                   ['Reportería al cliente', 'Dashboard operativo en línea', 'Reporte mensual en PDF'],
                   ['Reemplazo ante ausencia', 'Pool de guardias, cobertura inmediata', 'Variable, según disponibilidad'],
                   ['Foco operacional', 'Exclusivo B2B', 'Mixto B2B/residencial'],

--- a/app/guardias-seguridad-antofagasta/page.tsx
+++ b/app/guardias-seguridad-antofagasta/page.tsx
@@ -27,7 +27,7 @@ const faqs = [
   { question: '¿Por qué contratar guardias de seguridad en Antofagasta?', answer: 'Antofagasta, como capital minera de Chile, requiere seguridad especializada para proteger faenas mineras, puertos y zonas industriales. Nuestros guardias están 100% certificados OS10 por SERNAGEOMIN y tienen experiencia comprobada en operaciones de alto riesgo en zonas remotas del norte de Chile.' },
   { question: '¿Qué certificación OS10 tienen sus guardias en Antofagasta?', answer: 'El 100% de nuestros guardias cuenta con certificación OS10 vigente de SERNAGEOMIN, como exige el Decreto Supremo N°132 para todos los guardias de seguridad en Chile. Nuestro diferencial es que además del OS10 obligatorio, nuestros guardias en minería tienen capacitación especializada en protocolos mineros, primeros auxilios en altura y emergencias en zonas remotas.' },
   { question: '¿Cuánto cuesta contratar guardias de seguridad en Antofagasta?', answer: 'Depende de puestos, turnos y logística en zonas remotas. Enviamos propuesta cerrada en 24h con personal OS10 y supervisión 24/7.' },
-  { question: '¿Cuál es el tiempo de respuesta en Antofagasta?', answer: 'En Antofagasta ciudad tenemos tiempo de respuesta promedio de 15 minutos. Para faenas mineras en zonas remotas (María Elena, Sierra Gorda, etc.) contamos con guardias residentes en la faena y comunicación satelital con nuestra central de monitoreo 24/7.' }
+  { question: '¿Cuál es el tiempo de respuesta en Antofagasta?', answer: 'En Antofagasta ciudad, nuestros guardias siguen protocolos de reacción inmediata en el sitio (alerta + coordinación con central en menos de 2 minutos). Para faenas mineras en zonas remotas (María Elena, Sierra Gorda, etc.) contamos con guardias residentes en la faena y comunicación satelital con nuestra central de monitoreo 24/7, coordinada con Carabineros y servicios de emergencia.' }
 ];
 
 export default function GuardiasAntofagastaPage() {
@@ -88,7 +88,7 @@ export default function GuardiasAntofagastaPage() {
             </div>
             <div className="flex items-center bg-white/10 backdrop-blur-sm rounded-full px-4 py-2">
               <CheckCircle className="h-5 w-5 text-green-400 mr-2" />
-              <span className="text-white font-medium">Respuesta &lt;15 Min</span>
+              <span className="text-white font-medium">Central 24/7 Propia</span>
             </div>
           </div>
           
@@ -153,7 +153,7 @@ export default function GuardiasAntofagastaPage() {
               <Clock className="h-12 w-12 text-primary mb-4" />
               <h3 className="text-xl font-semibold mb-3">Respuesta Inmediata</h3>
               <p className="text-muted-foreground">
-                Tiempo de respuesta promedio de 15 minutos en Antofagasta ciudad. Para faenas remotas: guardias residentes en sitio con supervisión remota continua.
+                Protocolos de reacción inmediata en sitio con alerta a central en menos de 2 minutos. Para faenas remotas: guardias residentes en sitio con supervisión remota continua y comunicación satelital.
               </p>
             </div>
           </div>

--- a/app/guardias-seguridad-mineria-chile/page.tsx
+++ b/app/guardias-seguridad-mineria-chile/page.tsx
@@ -91,7 +91,7 @@ export default function GuardiasSeguridadMineriaPage() {
             </div>
             <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl p-6">
               <Award className="h-10 w-10 text-primary mb-3" />
-              <h3 className="text-white font-semibold text-lg mb-2">Respuesta menor a 15 min</h3>
+              <h3 className="text-white font-semibold text-lg mb-2">Coordinación 24/7 con central propia</h3>
               <p className="text-white/80 text-sm">Tiempos de respuesta garantizados ante emergencias</p>
             </div>
           </div>

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -44,7 +44,7 @@ Gard Security es una empresa de seguridad privada con base en Santiago, Chile, e
 - ${activeGuards} guardias activos en operación
 - ${activeClients} clientes B2B activos en todo Chile
 - Presencia física en ${citiesCovered} ciudades: Santiago, Antofagasta, Valparaíso, Concepción, Iquique, Puerto Montt, Rancagua, Chillán, Temuco, Viña del Mar
-- Tiempo de respuesta menor a 15 minutos ante incidentes en Santiago
+- Tiempo de respuesta promedio ${companyStats.avgIncidentResponseMinutesSantiago} minutos ante incidentes en zona urbana de Santiago
 - Monitoreo 24/7 con operadores dedicados
 - Tecnología propia: Sistema OPAI para gestión operativa con IA
 - Empresa fundada en ${foundedYear}, con equipo fundador de ${years} años de experiencia en el rubro

--- a/app/mejor-empresa-seguridad-chile/page.tsx
+++ b/app/mejor-empresa-seguridad-chile/page.tsx
@@ -38,7 +38,7 @@ const faqs = [
   { question: '¿Cuál es la empresa de seguridad más confiable de Santiago?', answer: `Gard Security opera en Santiago con ${companyStats.activeClients} clientes B2B activos, protegiendo edificios corporativos y centros de distribución con resultados verificables de reducción de mermas hasta 85%. Rating promedio 4.9/5 en Google Reviews con 99.9% de continuidad operacional.` },
   { question: '¿Todas las empresas de seguridad tienen guardias certificados OS10?', answer: 'Por ley, TODAS las empresas de seguridad deben tener 100% de sus guardias certificados OS10 (emitido por Carabineros de Chile, Depto. OS10). Sin embargo, muchas empresas operan parcialmente con personal sin certificación vigente, lo que es ilegal. Gard Security garantiza auditorías mensuales para verificar que el 100% del personal tenga OS10 vigente en todas las industrias, además de capacitación especializada adicional según el sector.' },
   { question: '¿Por qué Gard Security es considerada líder en seguridad B2B?', answer: 'Gard Security lidera en seguridad empresarial (B2B) por: 100% certificación OS10 en minería, reducción de mermas hasta 85% en logística (vs 40-50% promedio), cobertura en 10 ciudades (vs 3-5 promedio), rating 4.9/5 (vs 4.2 promedio), y especialización exclusiva en empresas sin servicios residenciales.' },
-  { question: '¿Cuál es el tiempo de respuesta ante incidentes?', answer: 'Respuesta garantizada menor a 15 minutos en zonas urbanas, con protocolos express y central de monitoreo 24/7.' },
+  { question: '¿Cuál es el tiempo de respuesta ante incidentes?', answer: `Tiempo de respuesta promedio ${companyStats.avgIncidentResponseMinutesSantiago} minutos en zona urbana de Santiago —medido sobre contratos activos—, con central de monitoreo 24/7 que coordina con carabineros, bomberos y ambulancia según el tipo de incidente.` },
   { question: '¿Cómo se comparan en rating con la industria?', answer: 'Gard Security: 4.9/5 (57 reseñas en Google); promedio industria 4.0-4.3/5.' },
   { question: '¿Qué cobertura tienen en Chile?', answer: '10 ciudades activas: Santiago, Antofagasta, Valparaíso, Concepción, Iquique, Puerto Montt, Rancagua, Chillán, Temuco y Viña del Mar.' },
   { question: '¿Qué certificaciones y normas cumplen?', answer: 'OS10 100% vigente, ISO 9001:2015, programa Compliance Ley 20.393, y protocolos específicos por industria.' },
@@ -54,38 +54,11 @@ const howToSteps = [
   { name: 'Alinear KPIs y reportes', text: 'Establecer KPIs: tiempo de respuesta, continuidad, incidentes y SLA mensuales.' },
 ];
 
-const reviews: Array<{
-  author: { name: string; type: 'Person' | 'Organization' };
-  datePublished: string;
-  ratingValue: number;
-  reviewBody: string;
-  name: string;
-}> = [
-  {
-    author: { name: 'Gerente de Seguridad Minera', type: 'Person' as const },
-    datePublished: '2025-05-01',
-    ratingValue: 5,
-    reviewBody:
-      'Gard mantuvo 100% OS10 en faena remota y redujo incidentes en 70% con monitoreo y protocolos en altura. Respuesta &lt;15 min.',
-    name: 'Liderazgo en minería',
-  },
-  {
-    author: { name: 'Director de Logística', type: 'Person' as const },
-    datePublished: '2025-04-20',
-    ratingValue: 5,
-    reviewBody:
-      'Reducción de mermas -85% en 6 meses. Guardias atentos, control de accesos y CCTV con analítica. Reportes claros y accionables.',
-    name: 'Resultados en logística',
-  },
-  {
-    author: { name: 'Administrador de Edificio Corporativo', type: 'Person' as const },
-    datePublished: '2025-04-05',
-    ratingValue: 5,
-    reviewBody:
-      'Recepción ejecutiva, guardias bilingües y protocolos de evacuación probados. Continuidad 99.9% en 12 meses.',
-    name: 'Excelencia corporativa',
-  },
-];
+// Reviews hardcoded inventados (Fase 1.3 residual) removidos: las quotes no
+// estaban respaldadas por consentimiento explícito de clientes y podían ser
+// clasificadas por Google como "self-serving review" bajo política 2019+.
+// El ReviewSchema mantiene aggregateRating (verificable en GMB) y cuando
+// haya testimonios reales en lib/data/testimonials.ts los sumamos.
 
 export default function MejorEmpresaSeguridadPage() {
   return (
@@ -114,11 +87,10 @@ export default function MejorEmpresaSeguridadPage() {
           url: 'https://www.gard.cl/mejor-empresa-seguridad-chile',
           type: 'LocalBusiness',
           image: 'https://www.gard.cl/logos/gard.svg',
-          description: 'Empresa #1 de seguridad privada B2B en Chile, 100% OS10 y cobertura en 10 ciudades.',
+          description: `Empresa #1 de seguridad privada B2B en Chile, 100% OS10 y cobertura en ${companyStats.citiesCovered} ciudades.`,
         }}
         aggregateRating={{ ratingValue: 4.9, reviewCount: 57, bestRating: 5, worstRating: 1 }}
-        reviews={reviews}
-        verificationUrl="https://maps.app.goo.gl/ywW2rQEWu4g4xxxy8"
+        verificationUrl={companyStats.gmbShortUrl}
       />
       <HowToSchema
         name="Cómo elegir la mejor empresa de seguridad en Chile"
@@ -192,8 +164,8 @@ export default function MejorEmpresaSeguridadPage() {
                     <td className="px-6 py-4 text-center text-muted-foreground">70-85% Real</td>
                   </tr>
                   <tr className="border-b">
-                    <td className="px-6 py-4 font-medium">Tiempo de respuesta emergencias</td>
-                    <td className="px-6 py-4 text-center text-green-600 font-bold">&lt;15 min</td>
+                    <td className="px-6 py-4 font-medium">Tiempo de respuesta emergencias (zona urbana)</td>
+                    <td className="px-6 py-4 text-center text-green-600 font-bold">{companyStats.avgIncidentResponseMinutesSantiago} min</td>
                     <td className="px-6 py-4 text-center text-muted-foreground">30-45 min</td>
                   </tr>
                   <tr className="border-b bg-muted/30">

--- a/app/ranking-empresas-seguridad-chile-2025/page.tsx
+++ b/app/ranking-empresas-seguridad-chile-2025/page.tsx
@@ -41,7 +41,7 @@ const ranking = [
     rating: '4.9/5',
     os10: '100%',
     cobertura: '10 ciudades',
-    diferenciador: 'B2B exclusivo, -85% mermas logística, respuesta <15 min',
+    diferenciador: 'B2B exclusivo, -85% mermas logística, continuidad 99.9%',
   },
   {
     name: 'Empresa B',
@@ -68,7 +68,7 @@ const faqs = [
   {
     question: '¿Por qué Gard es #1?',
     answer:
-      '100% OS10 auditado, 4.9/5 rating (57), cobertura en 10 ciudades, especialización B2B, reducción de mermas -85% y respuesta <15 min.',
+      '100% OS10 auditado, 4.9/5 rating (57), cobertura en 10 ciudades, especialización B2B, reducción de mermas -85% y continuidad operacional 99.9%.',
   },
   {
     question: '¿El ranking es público y verificable?',

--- a/app/servicios-por-industria/[servicio]/[industria]/components/ServicioIndustriaLanding.tsx
+++ b/app/servicios-por-industria/[servicio]/[industria]/components/ServicioIndustriaLanding.tsx
@@ -608,10 +608,10 @@ export default function ServicioIndustriaLanding({ content, params }: ServicioIn
           <div className="gard-container">
             <div className="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8">
               {[
-                { value: "+500", label: "Clientes Satisfechos" },
+                { value: "23", label: "Clientes B2B activos" },
                 { value: "24/7", label: "Servicio Continuo" },
-                { value: "15 min", label: "Tiempo de Respuesta" },
-                { value: "100%", label: "Personal Certificado" }
+                { value: "30 min", label: "Respuesta promedio (zona urbana)" },
+                { value: "100%", label: "Personal Certificado OS10" }
               ].map((stat, index) => (
                 <motion.div 
                   key={index}

--- a/components/seo/ReviewSchema.tsx
+++ b/components/seo/ReviewSchema.tsx
@@ -30,7 +30,13 @@ interface ReviewSchemaProps {
     description?: string;
   };
   aggregateRating: AggregateRatingInput;
-  reviews: ReviewItem[];
+  /**
+   * Opcional. Solo incluir si hay testimonios VERIFICADOS (consentimiento
+   * escrito del cliente). Si se pasan reviews inventados, Google puede
+   * clasificar el schema como "self-serving review" y aplicar manual
+   * action. En su ausencia, el schema emite solo aggregateRating y sameAs.
+   */
+  reviews?: ReviewItem[];
   /**
    * URL externa de verificación del rating (ej: Google Business Profile).
    * CRÍTICO pasar esto cuando se use aggregateRating — evita clasificación
@@ -44,7 +50,8 @@ interface ReviewSchemaProps {
  * Optimiza rich snippets y ayuda a las IAs a citar evidencias verificables.
  */
 export default function ReviewSchema({ itemReviewed, aggregateRating, reviews, verificationUrl }: ReviewSchemaProps) {
-  const schema = {
+  const hasVerifiedReviews = Array.isArray(reviews) && reviews.length > 0;
+  const schema: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'Product',
     name: itemReviewed.name,
@@ -60,7 +67,10 @@ export default function ReviewSchema({ itemReviewed, aggregateRating, reviews, v
       ...(verificationUrl ? { url: verificationUrl } : {}),
     },
     ...(verificationUrl ? { sameAs: [verificationUrl] } : {}),
-    review: reviews.map((review) => ({
+  };
+
+  if (hasVerifiedReviews) {
+    schema.review = reviews!.map((review) => ({
       '@type': 'Review',
       name: review.name ?? `${itemReviewed.name} - Reseña`,
       reviewBody: review.reviewBody,
@@ -76,8 +86,8 @@ export default function ReviewSchema({ itemReviewed, aggregateRating, reviews, v
         name: review.author.name,
       },
       ...(review.url ? { url: review.url } : {}),
-    })),
-  };
+    }));
+  }
 
   return (
     <script

--- a/components/sobre-nosotros/SobreNosotrosClient.tsx
+++ b/components/sobre-nosotros/SobreNosotrosClient.tsx
@@ -13,28 +13,9 @@ import ReviewSchema from '@/components/seo/ReviewSchema';
 import { companyStats } from '@/lib/data/company-stats';
 
 export default function SobreNosotrosClient() {
-  const reviews: Array<{
-    author: { name: string; type: 'Person' | 'Organization' };
-    datePublished: string;
-    ratingValue: number;
-    reviewBody: string;
-    name: string;
-  }> = [
-    {
-      author: { name: 'Cliente Corporativo', type: 'Person' as const },
-      datePublished: '2025-05-01',
-      ratingValue: 5,
-      reviewBody: 'Servicio confiable, respuesta <15 minutos y guardias OS10 auditados. Reportes claros y equipos profesionales.',
-      name: 'Resultados corporativos',
-    },
-    {
-      author: { name: 'Gerente de Logística', type: 'Person' as const },
-      datePublished: '2025-04-18',
-      ratingValue: 5,
-      reviewBody: 'Reducción de mermas -85% con control de accesos y supervisión 24/7. Excelente visibilidad operacional.',
-      name: 'Logística optimizada',
-    },
-  ];
+  // Reviews inventados (Fase 1.3 residual) removidos. El ReviewSchema mantiene
+  // aggregateRating verificable en GMB. Cuando haya testimonios reales en
+  // lib/data/testimonials.ts con consentimiento explícito se pasan al schema.
 
   return (
     <>
@@ -50,8 +31,7 @@ export default function SobreNosotrosClient() {
           description: 'Líder B2B en seguridad privada en Chile con 4.9/5 rating y 100% guardias OS10.',
         }}
         aggregateRating={{ ratingValue: 4.9, reviewCount: 57, bestRating: 5, worstRating: 1 }}
-        reviews={reviews}
-        verificationUrl="https://maps.app.goo.gl/ywW2rQEWu4g4xxxy8"
+        verificationUrl={companyStats.gmbShortUrl}
       />
       
       {/* Hero Section */}
@@ -112,7 +92,7 @@ export default function SobreNosotrosClient() {
             <h3 className="text-heading-4 mb-4">Datos operativos</h3>
             <ul className="space-y-2 text-muted-foreground">
               <li>• Continuidad operacional: 99.9%</li>
-              <li>• Tiempo de respuesta: &lt;15 minutos zonas urbanas</li>
+              <li>• Tiempo de respuesta promedio: {companyStats.avgIncidentResponseMinutesSantiago} minutos zonas urbanas</li>
               <li>• Reducción de mermas en logística: hasta -85%</li>
               <li>• Cobertura: Santiago, Antofagasta, Valparaíso, Concepción, Iquique, Puerto Montt, Rancagua, Chillán, Temuco, Viña del Mar</li>
             </ul>

--- a/docs/blog_posts/cuanto-cuesta-contratar-guardias-seguridad-chile-2025.md
+++ b/docs/blog_posts/cuanto-cuesta-contratar-guardias-seguridad-chile-2025.md
@@ -257,7 +257,7 @@ Costo Base = (N° guardias) × (Costo guardia/mes según turno) × (Factor regi�
 | **Certificación OS10** | 100% personal | 60-70% | +40% más certificados |
 | **Tecnología incluida** | CCTV básico, checkpoints | Solo guardias | +$300k valor |
 | **Monitoreo 24/7** | Central propia | Subcontratado | Mayor control |
-| **Tiempo respuesta** | <15 min | 30-45 min | 2x más rápido |
+| **Tiempo respuesta (zona urbana)** | 30 min promedio | 30-45 min | Rango bajo del mercado |
 | **Continuidad** | 99.9% | 95-97% | Menos ausencias |
 | **Resultados logística** | -85% mermas | -40-50% | 1.7x mejor |
 
@@ -438,7 +438,7 @@ Costo Base = (N° guardias) × (Costo guardia/mes según turno) × (Factor regi�
 2. **Experiencia verificable** (referencias, años en el rubro)
 3. **Tecnología de respaldo** (CCTV, monitoreo, no solo guardias)
 4. **Cobertura de ausencias** (reemplazos garantizados)
-5. **Tiempo de respuesta** (<15 min en emergencias)
+5. **Tiempo de respuesta** (SLA claro, medido sobre contratos reales)
 6. **Precio competitivo** (pero no el más bajo)
 
 ### Recomendación Final
@@ -457,7 +457,7 @@ Costo Base = (N° guardias) × (Costo guardia/mes según turno) × (Factor regi�
 
 **Gard Security:** equipo fundador con más de 8 años protegiendo empresas en Chile
 - ✅ 100% personal certificado OS10 (minería)
-- ✅ Respuesta <15 minutos
+- ✅ Respuesta promedio 30 minutos en zona urbana Santiago
 - ✅ Tecnología incluida
 - ✅ Monitoreo 24/7 central propia
 - ✅ Cotización sin compromiso en 24-48h

--- a/docs/blog_posts/la-importancia-de-la-central-de-monitoreo-en-la-seguridad-de-empresas.md
+++ b/docs/blog_posts/la-importancia-de-la-central-de-monitoreo-en-la-seguridad-de-empresas.md
@@ -12,7 +12,7 @@ imageUrl: >-
   /images/blog/la-importancia-de-la-central-de-monitoreo-en-la-seguridad-de-empresas.jpg
 ---
 
-> **En resumen:** La central de monitoreo supervisa CCTV, alarmas y sensores en tiempo real 24/7. Gard Security opera central propia con operadores especializados y respuesta en menos de 15 minutos. Esencial para empresas e industrias.
+> **En resumen:** La central de monitoreo supervisa CCTV, alarmas y sensores en tiempo real 24/7. Gard Security opera central propia con operadores especializados, protocolos de reacción inmediata en sitio y coordinación con Carabineros y servicios de emergencia. Esencial para empresas e industrias.
 
 		<div data-elementor-type="wp-post" data-elementor-id="2729" class="elementor elementor-2729" data-elementor-post-type="post">
 				<div class="elementor-element elementor-element-11084899 e-flex e-con-boxed e-con e-parent" data-id="11084899" data-element_type="container">

--- a/lib/data/company-stats.ts
+++ b/lib/data/company-stats.ts
@@ -51,6 +51,28 @@ export const companyStats = {
   monitoringCenter247: true,
 
   /**
+   * Tiempo promedio de respuesta ante incidente en zona urbana (Santiago),
+   * en minutos. Medido internamente sobre contratos activos. No inflar a
+   * "<15 min" ni "tiempo récord": la honestidad verificable gana a Google
+   * y al cliente corporativo, que compara con lo que la industria entrega
+   * realmente (30-45 min).
+   */
+  avgIncidentResponseMinutesSantiago: 30,
+
+  /**
+   * Días hábiles promedio para onboarding de un nuevo sitio en Santiago
+   * (desde firma de contrato hasta guardia OS10 asignado y activo).
+   */
+  onboardingBusinessDaysSantiago: 5,
+
+  /**
+   * Continuidad operacional (uptime guardia vs contrato), medida como
+   * porcentaje de turnos cubiertos sobre turnos contratados. Auditable
+   * internamente sobre el histórico de contratos.
+   */
+  operationalContinuityPct: 99.9,
+
+  /**
    * URLs verificables del perfil público para cross-validación por Google
    * (evita clasificación de AggregateRating como "self-serving reviews").
    */

--- a/lib/data/getCiudadServicioContent.ts
+++ b/lib/data/getCiudadServicioContent.ts
@@ -1,5 +1,6 @@
 import { CiudadData, ciudades } from './ciudad-data';
 import { servicesMetadata } from '@/app/servicios/serviceMetadata';
+import { companyStats } from './company-stats';
 
 export interface CiudadServicioContent {
   title: string;
@@ -247,7 +248,7 @@ const generarFAQs = (ciudad: CiudadData, servicioNombre: string): { pregunta: st
   return [
     {
       pregunta: `¿Cuál es el tiempo de respuesta de ${servicioNombre} en ${ciudad.nombre}?`,
-      respuesta: `Nuestro tiempo de respuesta en ${ciudad.nombre} varía según el sector, pero garantizamos atención inmediata en menos de 15 minutos en el área urbana y tiempos optimizados para sectores más alejados como ${ciudad.barriosImportantes[ciudad.barriosImportantes.length - 1]}.`
+      respuesta: `Nuestro tiempo de respuesta promedio en ${ciudad.nombre} es de ${companyStats.avgIncidentResponseMinutesSantiago} minutos en zona urbana —medido sobre contratos activos— con tiempos adaptados para sectores más alejados como ${ciudad.barriosImportantes[ciudad.barriosImportantes.length - 1]}.`
     },
     {
       pregunta: `¿Tienen personal local en ${ciudad.nombre} para el servicio de ${servicioNombre}?`,

--- a/lib/data/industry-faqs.ts
+++ b/lib/data/industry-faqs.ts
@@ -69,7 +69,7 @@ export const industryFAQs: Record<string, FAQItem[]> = {
     },
     {
       question: '¿Qué hacen si ocurre un intento de robo en tránsito?',
-      answer: 'Nuestro protocolo incluye: activación inmediata de botón de pánico, notificación automática a Carabineros con ubicación exacta, despliegue de equipo de respuesta rápida más cercano, coordinación con autoridades para intercepción, y seguimiento hasta resolución. Contamos con tiempos de respuesta < 15 minutos en rutas principales.'
+      answer: 'Nuestro protocolo incluye: activación inmediata de botón de pánico, notificación automática a Carabineros con ubicación exacta, despliegue de equipo de respuesta rápida más cercano, coordinación con autoridades para intercepción, y seguimiento hasta resolución. Contamos con central de monitoreo 24/7 y tiempos de respuesta adaptados al tipo de sitio y zona geográfica.'
     }
   ],
   'edificios-corporativos': [


### PR DESCRIPTION
## Contexto

Al preparar la plantilla de oro de Santiago (Fase 2.2), Carlos confirmó que el tiempo promedio real de respuesta ante incidentes en Santiago zona urbana es **30 minutos**, no \"<15 min\" como aparecía en 26 lugares del sitio.

Además, mientras limpiaba ese claim encontré **4 páginas con arrays de \`reviews\` hardcoded** (testimonios inventados atribuidos a \"Gerente de Seguridad Minera\", \"Director de Logística\", etc) que aún alimentaban el \`ReviewSchema\` JSON-LD. Es el mismo problema que Fase 1.3 intentó resolver y se me escapó en las páginas SEO específicas.

Ambos son issues graves de E-E-A-T que **hay que corregir antes de publicar Santiago**.

## Cambios

### 1. Response time integrity

- Nuevo campo \`avgIncidentResponseMinutesSantiago: 30\` en \`companyStats\` (+ \`onboardingBusinessDaysSantiago: 5\` y \`operationalContinuityPct: 99.9\` como bonus).
- Purga de \"<15 min\" / \"<15 minutos\" / \"menor a 15 min\" en **17 archivos live** (código + 2 blog posts).
- Para Antofagasta, donde no hay dato confirmado, se removió el número específico y se reemplazó por descriptor cualitativo.

### 2. Fake reviews cleanup (Fase 1.3 residual)

- \`ReviewSchema.reviews\` ahora es **opcional**. Si ausente, el JSON-LD emite solo \`aggregateRating\` (respaldado por GMB real) y \`sameAs\`.
- Eliminadas arrays hardcoded de:
  - \`app/mejor-empresa-seguridad-chile/page.tsx\`
  - \`app/empresa-seguridad-privada-chile/page.tsx\`
  - \`app/empresa-guardias-seguridad-chile/page.tsx\`
  - \`components/sobre-nosotros/SobreNosotrosClient.tsx\`

El rating 4.9 / 57 reviews queda porque es verificable en Google Business Profile; solo se eliminan los objetos \`Review\` inventados inline.

## Validación

- ✅ \`npm run typecheck\`
- ✅ \`npm run build\` (490 páginas)
- Post-deploy: \`grep -c \"<15\" https://www.gard.cl/...\` debería dar 0.

## Diff resumen

| Cosa | Antes | Ahora |
|---|---|---|
| Tiempo respuesta Santiago | \"<15 min\" (inflado) | 30 min (real, medido) |
| ReviewSchema con reviews inventados | 12 reviews fake sumados | Solo AggregateRating verificable |
| Stat card \"+500 clientes\" en landings ciudad/industria | \"+500\" (inflado) | 23 (real) |

## Por qué importa

- Google \"self-serving review\" policy 2019+: schema con reviews propios sin respaldo = manual action candidate.
- Helpful Content: claims no verificables son señal de \"low-quality content\".
- Un periodista o competidor que verifica \"<15 min\" contra SLAs reales detecta la discrepancia.

Esto también desbloquea Santiago Fase 2.2 con el dato correcto de baseline.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes sitewide SEO copy and structured data output (review JSON-LD), which can affect search/rich result behavior if the new stats or schema expectations are incorrect.
> 
> **Overview**
> Updates marketing/SEO claims across multiple landing pages and docs to replace the inflated "<15 min" response-time messaging with a single source-of-truth metric (`companyStats.avgIncidentResponseMinutesSantiago = 30`) and related operational stats (e.g. `operationalContinuityPct`).
> 
> Removes residual hardcoded testimonial arrays and makes `ReviewSchema.reviews` optional so JSON-LD emits only `aggregateRating`/`sameAs` backed by the Google Business verification URL (`companyStats.gmbShortUrl`), reducing risk of "self-serving review" policy violations. Also refreshes some stat cards (e.g. "+500 clientes" → "23 clientes B2B activos") and adjusts pages without confirmed numbers (e.g. Antofagasta) to qualitative response-time wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5716a5d7e7ccba9725c9a5331e6282ab7b41207. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->