### PR TITLE
fix(opai): poblar 6 Cloudflare Image IDs reales (hotfix prod)

### DIFF
--- a/lib/data/opai-images.ts
+++ b/lib/data/opai-images.ts
@@ -17,37 +17,37 @@
  */
 export const OPAI_IMAGES = {
   portalCliente: {
-    id: "PENDING_UPLOAD",
+    id: "bb2de891-f22d-4b5d-dc93-b24390133700",
     alt: "Dashboard del Portal Cliente de OPAI con visibilidad 24/7 de cumplimiento de rondas, KPIs operativos y actividad del equipo de guardias en terreno",
     width: 1024,
     height: 672,
   },
   mapaRondas: {
-    id: "PENDING_UPLOAD",
+    id: "871efea4-5dc8-4986-4c16-9bb682c24d00",
     alt: "Operación en vivo de OPAI con mapa de rondas GPS, checkpoints verificados y timeline de marcaciones por guardia",
     width: 1024,
     height: 678,
   },
   portalSupervisor: {
-    id: "PENDING_UPLOAD",
+    id: "857e0b75-b1dc-4ced-c3bf-da5fe5d0a900",
     alt: "Portal Supervisor de OPAI con calendario de pauta mensual, acciones rápidas operativas y control de turnos por guardia",
     width: 1024,
     height: 903,
   },
   portalControlAcceso: {
-    id: "PENDING_UPLOAD",
+    id: "94b1ba54-02c3-44f2-4a2b-12c380934e00",
     alt: "Portal Control de Acceso de OPAI con registro digital de visitantes, KPIs de flujo y actividad reciente en tiempo real",
     width: 1024,
     height: 901,
   },
   portalGuardia: {
-    id: "PENDING_UPLOAD",
+    id: "26cb4489-8933-4fac-2bbc-a0e997933200",
     alt: "Portal Guardia de OPAI con autoservicio del trabajador: marcación de asistencia, protocolo operativo, pauta y documentos laborales",
     width: 1024,
     height: 905,
   },
   pautaMensualErp: {
-    id: "PENDING_UPLOAD",
+    id: "8f4cb54b-bd17-42fc-38cf-cddf6848ba00",
     alt: "Vista completa del ERP OPAI de Gard Security con planificación de pauta mensual, módulos de operaciones, personas, payroll, finanzas y cumplimiento",
     width: 1024,
     height: 681,


### PR DESCRIPTION
## Contexto urgente

El PR #21 mergeó a main mi commit base de OPAI (`02aea86 feat(opai): showcase landings`), pero NO incluyó el commit con los UUIDs reales de Cloudflare porque ese commit se creó después del push de #21.

Resultado actual en producción: las 5 páginas del showcase OPAI están renderizando imágenes 404.

## Qué hace este PR

Un solo commit: `chore(opai): poblar 6 Cloudflare Image IDs reales del showcase OPAI`

Reemplaza los 6 placeholders `"PENDING_UPLOAD"` en `lib/data/opai-images.ts` con los UUIDs que retornó Cloudflare Images tras subir las 6 capturas anonimizadas:

| Clave | ID |
|---|---|
| portalCliente | bb2de891-f22d-4b5d-dc93-b24390133700 |
| mapaRondas | 871efea4-5dc8-4986-4c16-9bb682c24d00 |
| portalSupervisor | 857e0b75-b1dc-4ced-c3bf-da5fe5d0a900 |
| portalControlAcceso | 94b1ba54-02c3-44f2-4a2b-12c380934e00 |
| portalGuardia | 26cb4489-8933-4fac-2bbc-a0e997933200 |
| pautaMensualErp | 8f4cb54b-bd17-42fc-38cf-cddf6848ba00 |

Verificado: las 6 URLs `imagedelivery.net/gGw8cfmEZedi85dYm6qcFw/<id>/public` responden 200 desde el CDN global.

## Páginas afectadas (quedan arregladas)

- `/` (sección OPAI homepage)
- `/tecnologia-seguridad` (7 imágenes)
- `/control-rondas-gps`
- `/portal-cliente`

## Test plan

- [ ] Verificar en preview Vercel que las 4 URLs anteriores cargan las imágenes
- [ ] Merge rápido y confirmar deploy en producción

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk (static data change) but directly affects user-facing asset loading; incorrect UUIDs would keep images broken in production.
> 
> **Overview**
> Fixes broken OPAI showcase images by replacing six `PENDING_UPLOAD` placeholders in `lib/data/opai-images.ts` with the real Cloudflare Images UUIDs for each screenshot (e.g. `portalCliente`, `mapaRondas`, `portalSupervisor`, `portalControlAcceso`, `portalGuardia`, `pautaMensualErp`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc998f1a54994a2d124cacdff40d0225cb46e0ae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->