### PR TITLE
feat(nav): dropdown Tecnologías con sub-items OPAI

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -21,7 +21,11 @@ const navLinks = [
     label: 'Industrias',
     hasMegaMenu: true
   },
-  { href: '/tecnologia-seguridad', label: 'Tecnologías' },
+  {
+    href: '/tecnologia-seguridad',
+    label: 'Tecnologías',
+    hasMegaMenu: true,
+  },
   { href: '/reclutamiento', label: 'Trabaja con Nosotros' },
   { href: '/blog', label: 'Blog' },
   { href: '/cotizar', label: 'Cotizar', isCTA: true },
@@ -45,8 +49,20 @@ const megaMenuData = {
     { title: 'Corporativo', href: '/industrias/edificios-corporativos', desc: 'Vigilancia para oficinas y edificios.' },
     { title: 'Construcción', href: '/industrias/construccion', desc: 'Protección de obras y maquinaria.' },
     { title: 'Educación', href: '/industrias/educacion', desc: 'Seguridad para colegios y universidades.' },
+  ],
+  Tecnologías: [
+    { title: 'OPAI · Plataforma completa', href: '/tecnologia-seguridad', desc: 'ERP propio de Gard Security: pauta, rondas, payroll, cumplimiento e IA.' },
+    { title: 'Portal Cliente', href: '/portal-cliente', desc: 'Dashboard 24/7 con KPIs, Trust Score y actividad del equipo en sitio.' },
+    { title: 'Control de Rondas GPS', href: '/control-rondas-gps', desc: 'Verificación GPS de checkpoints, timeline de marcaciones y Trust Score auditable.' },
   ]
 };
+
+// Rutas que deben marcar "Tecnologías" como activo en la nav
+const TECNOLOGIAS_ACTIVE_PATHS = [
+  '/tecnologia-seguridad',
+  '/portal-cliente',
+  '/control-rondas-gps',
+];
 
 export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
@@ -140,17 +156,22 @@ export default function Header() {
 
         {/* Navegación de escritorio */}
         <nav className="hidden md:flex items-center space-x-6 lg:space-x-8 h-full">
-          {navLinks.map(({ href, label, isCTA, hasMegaMenu }) => (
-            <div key={href} className="relative h-full flex items-center" onMouseEnter={() => hasMegaMenu && setHoveredLink(label)}>
-              <Link
-                href={href}
-                className={getNavLinkClasses(pathname === href, isCTA)}
-              >
-                {label}
-                {hasMegaMenu && <ChevronDown className={`w-4 h-4 transition-transform duration-300 ${hoveredLink === label ? 'rotate-180' : ''}`} />}
-              </Link>
-            </div>
-          ))}
+          {navLinks.map(({ href, label, isCTA, hasMegaMenu }) => {
+            const isActive =
+              pathname === href ||
+              (label === 'Tecnologías' && TECNOLOGIAS_ACTIVE_PATHS.includes(pathname ?? ''));
+            return (
+              <div key={href} className="relative h-full flex items-center" onMouseEnter={() => hasMegaMenu && setHoveredLink(label)}>
+                <Link
+                  href={href}
+                  className={getNavLinkClasses(isActive, isCTA)}
+                >
+                  {label}
+                  {hasMegaMenu && <ChevronDown className={`w-4 h-4 transition-transform duration-300 ${hoveredLink === label ? 'rotate-180' : ''}`} />}
+                </Link>
+              </div>
+            );
+          })}
           <ThemeToggle />
         </nav>
 
@@ -219,27 +240,55 @@ export default function Header() {
               overflow: 'auto'
             }}
           >
-            <nav className="flex flex-col items-center space-y-8 p-8 mt-4">
-              {navLinks.map(({ href, label, isCTA }) => (
-                <Link
-                  key={href}
-                  href={href}
-                  className={isCTA 
-                    ? "bg-primary text-white px-6 py-2 rounded-xl hover:bg-accent transition text-lg font-semibold"
-                    : `
-                      text-lg font-semibold transition-colors
-                      ${pathname === href 
-                        ? 'text-primary font-bold' 
-                        : isDarkMode 
-                          ? 'text-white hover:text-primary' 
-                          : 'text-black hover:text-primary/80'
+            <nav className="flex flex-col items-center space-y-6 p-8 mt-4">
+              {navLinks.map(({ href, label, isCTA, hasMegaMenu }) => {
+                const subItems = hasMegaMenu ? megaMenuData[label as keyof typeof megaMenuData] : undefined;
+                const isActive =
+                  pathname === href ||
+                  (label === 'Tecnologías' && TECNOLOGIAS_ACTIVE_PATHS.includes(pathname ?? ''));
+                return (
+                  <div key={href} className="flex flex-col items-center space-y-3">
+                    <Link
+                      href={href}
+                      className={isCTA
+                        ? 'bg-primary text-white px-6 py-2 rounded-xl hover:bg-accent transition text-lg font-semibold'
+                        : `
+                          text-lg font-semibold transition-colors
+                          ${isActive
+                            ? 'text-primary font-bold'
+                            : isDarkMode
+                              ? 'text-white hover:text-primary'
+                              : 'text-black hover:text-primary/80'
+                          }
+                        `
                       }
-                    `
-                  }
-                >
-                  {label}
-                </Link>
-              ))}
+                    >
+                      {label}
+                    </Link>
+                    {subItems && (
+                      <div className="flex flex-col items-center space-y-2 pl-2">
+                        {subItems.map((item) => (
+                          <Link
+                            key={item.href}
+                            href={item.href}
+                            className={`
+                              text-sm transition-colors
+                              ${pathname === item.href
+                                ? 'text-primary font-semibold'
+                                : isDarkMode
+                                  ? 'text-white/80 hover:text-primary'
+                                  : 'text-gray-700 hover:text-primary'
+                              }
+                            `}
+                          >
+                            {item.title}
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
               <div className="mt-4">
                 <ThemeToggle />
               </div>


### PR DESCRIPTION
## Contexto

Tras el merge de PR #22 (showcase OPAI), las 2 landings nuevas `/portal-cliente` y `/control-rondas-gps` quedaron sin entry point desde la navbar — solo eran descubribles por URL directa o desde links internos de `/tecnologia-seguridad`.

## Cambio

Convierte el link plano \"Tecnologías\" del Header en mega-menú (mismo patrón que Servicios/Industrias) con los 3 sub-items OPAI.

### Desktop (hover sobre \"Tecnologías\")

| Título | Ruta | Descripción |
|---|---|---|
| OPAI · Plataforma completa | \`/tecnologia-seguridad\` | ERP propio de Gard |
| Portal Cliente | \`/portal-cliente\` | Dashboard 24/7 |
| Control de Rondas GPS | \`/control-rondas-gps\` | Verificación GPS + Trust Score |

### Mobile

Los 3 sub-items se renderizan indentados bajo el link padre. Como efecto secundario, Servicios e Industrias también exponen ahora sus sub-items en mobile (antes el menú mobile solo mostraba el top-level aunque \`hasMegaMenu: true\`).

### Active state

\`TECNOLOGIAS_ACTIVE_PATHS\` marca \"Tecnologías\" como activo cuando el usuario navega a cualquiera de las 3 sub-rutas, no solo la principal.

## Test plan

- [ ] Hover \"Tecnologías\" en desktop abre dropdown con los 3 items
- [ ] Click en cada sub-item navega a la URL correcta
- [ ] En móvil, el link \"Tecnologías\" + sub-items aparecen en el drawer
- [ ] Navegando a \`/portal-cliente\` o \`/control-rondas-gps\`, el item \"Tecnologías\" de la navbar queda en estado activo

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only navigation changes; main risk is incorrect active-state logic or broken links in the new mega menu/mobile submenus.
> 
> **Overview**
> Adds a new **"Tecnologías" mega menu** (matching the existing Servicios/Industrias pattern) that exposes three OPAI-related destinations: `/tecnologia-seguridad`, `/portal-cliente`, and `/control-rondas-gps`.
> 
> Updates active-link highlighting so **"Tecnologías" remains active** when visiting any of those sub-routes via `TECNOLOGIAS_ACTIVE_PATHS`, and extends the mobile drawer to render mega-menu sub-items (so Servicios/Industrias sub-items now appear on mobile as well).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c02197634da056096de93d6ca77f6d60bbbce52. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->