### PR TITLE
feat(images): reemplazar fotos stock de guardias con fotos reales Gar…

### DIFF
--- a/app/(landing-cotizador-inteligente)/cotizador-inteligente/page.tsx
+++ b/app/(landing-cotizador-inteligente)/cotizador-inteligente/page.tsx
@@ -31,7 +31,7 @@ import { testimonials } from '@/lib/data/testimonials';
 const LOGO_GARD_BLANCO = '49b89002-6bb9-41b9-50ad-e6b91e5f6d00';
 const ESCUDO_GARD_BLANCO = 'f1cad221-0c11-43c4-3142-a53a6febbd00';
 const HERO_VIDEO_ID = '173a0d7d07ffa39bb4c93e422d676e65';
-const GUARDIA_IMAGEN_ID = '5eea1064-8a2d-4e8b-5606-d28775467a00'; // Imagen de guardia trabajando
+const GUARDIA_IMAGEN_ID = '57d32c87-0757-48e9-747f-2f7e66737100'; // Equipo de guardias Gard con bandera chilena
 
 // Definir el metadata directamente en este archivo para evitar problemas de importación
 const metadataInfo = {

--- a/app/data/servicios.ts
+++ b/app/data/servicios.ts
@@ -27,15 +27,15 @@ export const servicios: Servicio[] = [
     slug: "guardias-de-seguridad",
     icon: "ShieldCheck",
     description: "Guardias profesionales, entrenados y certificados para proteger personas, activos e instalaciones.",
-    heroImageId: "c0a460385f6fb9e90343feb3a97c55c3",
+    heroImageId: "57d32c87-0757-48e9-747f-2f7e66737100",
     gallery: [
-      "bc045c39-36bc-4abb-348d-c589687cb400",
-      "eed0de62-d623-47bd-0a3f-d2ca692c6300",
-      "2dd1b06a-afca-448a-8aaf-a995b00dd300",
-      "1106aceb-986e-4176-a9a9-f0ec1f80f700",
-      "5b95423f-4c59-4205-7b90-52e0667ca200",
-      "04e7aafd-831d-4b6f-666c-116605cc4400",
-      "fb852267-cb0c-4e3e-fa90-136c201e7000"
+      "4613e018-4925-4fb0-1fee-ed8ede43cd00",
+      "a89d3b2e-9738-4c67-c34f-3682a516c800",
+      "b0818218-7e38-4d9b-6dcf-5538e24b4e00",
+      "0b92cbb0-137d-45a1-eda4-94c70eff7600",
+      "1e7b161c-a76a-44bf-2a38-67b0631f8f00",
+      "29d16f73-5388-479a-a0ad-84774cbce300",
+      "2539041c-4815-4194-1656-fa6993014200"
     ],
     keywords: [
       "guardias de seguridad",

--- a/app/empresa-guardias-seguridad-chile/page.tsx
+++ b/app/empresa-guardias-seguridad-chile/page.tsx
@@ -137,8 +137,8 @@ export default function EmpresaGuardiasSeguridadPage() {
       <section className="gard-hero min-h-[70vh] flex flex-col justify-center items-center relative overflow-hidden">
         <div className="absolute inset-0">
           <CloudflareImage
-            imageId="77e4d99e-a497-44ad-6c70-88cc1d7f2e00"
-            alt="Guardias de seguridad de Gard en operación"
+            imageId="57d32c87-0757-48e9-747f-2f7e66737100"
+            alt="Equipo de guardias de seguridad Gard Security certificados OS10 frente a edificio corporativo con bandera chilena en Santiago, Chile"
             fill
             className="object-cover"
             priority

--- a/app/empresa-seguridad-privada-chile/page.tsx
+++ b/app/empresa-seguridad-privada-chile/page.tsx
@@ -125,8 +125,8 @@ export default function EmpresaSeguridadPrivadaPage() {
       <section className="gard-hero min-h-[70vh] flex flex-col justify-center items-center relative overflow-hidden">
         <div className="absolute inset-0">
           <CloudflareImage
-            imageId="2c554c0e-8f87-4f58-1ad5-29cbe6360600"
-            alt="Equipo de seguridad privada de Gard Security"
+            imageId="4613e018-4925-4fb0-1fee-ed8ede43cd00"
+            alt="Equipo de guardias Gard Security en institución patrimonial en Santiago, Chile, certificados OS10"
             fill
             className="object-cover"
             priority

--- a/app/guardias-de-seguridad-privada-para-empresas/page.tsx
+++ b/app/guardias-de-seguridad-privada-para-empresas/page.tsx
@@ -6,6 +6,9 @@ import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema';
 import FAQSchema from '@/components/seo/FAQSchema';
 import ServiceSchema from '@/components/seo/ServiceSchema';
 import FormularioCotizacionSeccion from '@/app/components/FormularioCotizacionSeccion';
+import CloudflareImage from '@/components/CloudflareImage';
+import GuardiasEnAccion from '@/components/secciones/GuardiasEnAccion';
+import { cloudflareImages } from '@/lib/images';
 import { companyStats } from '@/lib/data/company-stats';
 
 const BASE_URL = 'https://www.gard.cl';
@@ -155,6 +158,31 @@ export default function GuardiasParaEmpresasPage() {
           ],
         }}
       />
+
+      {/* Banner hero con foto real de guardias Gard */}
+      <section
+        className="relative w-full h-[320px] md:h-[460px] lg:h-[520px] overflow-hidden"
+        aria-label="Equipo Gard Security en instalación patrimonial"
+      >
+        <CloudflareImage
+          imageId={cloudflareImages.guardias.panoramico}
+          alt="Equipo de guardias de seguridad Gard Security certificados OS10 frente a edificio patrimonial en Chile"
+          fill
+          priority
+          objectFit="cover"
+          sizes="100vw"
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/50 to-black/70" />
+        <div className="relative z-10 h-full container px-4 mx-auto max-w-5xl flex flex-col justify-end pb-10 md:pb-14">
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-white/15 backdrop-blur-sm text-white text-sm font-semibold mb-4 w-fit">
+            <Shield className="h-4 w-4" />
+            <span>Guardias Gard Security — OS10 · Chile</span>
+          </div>
+          <p className="text-white text-lg md:text-2xl max-w-3xl font-medium drop-shadow">
+            {companyStats.activeGuards} guardias certificados OS10 protegiendo empresas en {companyStats.citiesCovered} ciudades de Chile.
+          </p>
+        </div>
+      </section>
 
       {/* Hero */}
       <section className="w-full py-16 md:py-24 lg:py-28 bg-gradient-to-br from-primary/5 via-background to-primary/5 dark:from-primary/10 dark:via-background dark:to-primary/10">
@@ -396,6 +424,9 @@ export default function GuardiasParaEmpresasPage() {
           </Button>
         </div>
       </section>
+
+      {/* Galería SEO-rica: guardias en acción */}
+      <GuardiasEnAccion />
 
       {/* Cotización */}
       <FormularioCotizacionSeccion prefillServicio="Guardias de Seguridad" />

--- a/app/guardias-edificios-corporativos-santiago/page.tsx
+++ b/app/guardias-edificios-corporativos-santiago/page.tsx
@@ -54,7 +54,7 @@ export default function GuardiasEdificiosPage() {
 
       <section className="gard-hero min-h-[70vh] flex flex-col justify-center items-center relative overflow-hidden">
         <div className="absolute inset-0">
-          <CloudflareImage imageId="86f9c63c-0372-46c8-9f30-19631ac2e100" alt="Guardias para edificios corporativos Santiago" fill className="object-cover" priority />
+          <CloudflareImage imageId="a89d3b2e-9738-4c67-c34f-3682a516c800" alt="Guardia de seguridad Gard Security en recepción de edificio corporativo premium en Santiago" fill className="object-cover" priority />
           <div className="absolute inset-0 bg-black/60"></div>
         </div>
         

--- a/app/guardias-seguridad-antofagasta/page.tsx
+++ b/app/guardias-seguridad-antofagasta/page.tsx
@@ -54,8 +54,8 @@ export default function GuardiasAntofagastaPage() {
       <section className="gard-hero min-h-[70vh] flex flex-col justify-center items-center relative overflow-hidden">
         <div className="absolute inset-0">
           <CloudflareImage
-            imageId="a8f97e4d-3c02-4e12-c4b6-24c1da8ddb00"
-            alt="Guardias de seguridad en Antofagasta"
+            imageId="22439039-6cb0-4ed4-a362-5aebe3ffaa00"
+            alt="Guardia Gard Security en institución pública de la Región de Atacama / Antofagasta"
             fill
             className="object-cover"
             priority

--- a/app/guardias-seguridad-mineria-chile/page.tsx
+++ b/app/guardias-seguridad-mineria-chile/page.tsx
@@ -54,7 +54,7 @@ export default function GuardiasSeguridadMineriaPage() {
 
       <section className="gard-hero min-h-[70vh] flex flex-col justify-center items-center relative overflow-hidden">
         <div className="absolute inset-0">
-          <CloudflareImage imageId="77e4d99e-a497-44ad-6c70-88cc1d7f2e00" alt="Guardias de seguridad en faena minera Chile" fill className="object-cover" priority />
+          <CloudflareImage imageId="29d16f73-5388-479a-a0ad-84774cbce300" alt="Guardia Gard Security en control de acceso de faena minera en Chile, certificado OS10" fill className="object-cover" priority />
           <div className="absolute inset-0 bg-black/60"></div>
         </div>
         

--- a/app/guardias-seguridad-valparaiso/page.tsx
+++ b/app/guardias-seguridad-valparaiso/page.tsx
@@ -54,8 +54,8 @@ export default function GuardiasValparaisoPage() {
       <section className="gard-hero min-h-[70vh] flex flex-col justify-center items-center relative overflow-hidden">
         <div className="absolute inset-0">
           <CloudflareImage
-            imageId="8a12ef3b-4d91-4c89-e865-d1a2c4567b00"
-            alt="Guardias de seguridad en Valparaíso"
+            imageId="b0818218-7e38-4d9b-6dcf-5538e24b4e00"
+            alt="Guardia Gard Security en recepción corporativa en Valparaíso, certificada OS10"
             fill
             className="object-cover"
             priority

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -169,8 +169,8 @@ export default function Home() {
             
             <div className="relative h-[500px] rounded-2xl overflow-hidden">
               <CloudflareImage
-                imageId="2c554c0e-8f87-4f58-1ad5-29cbe6360600"
-                alt="Equipo profesional de Gard Security durante reunión de planificación de seguridad con clientes empresariales"
+                imageId="57d32c87-0757-48e9-747f-2f7e66737100"
+                alt="Equipo de guardias de seguridad Gard Security certificados OS10 en edificio corporativo en Santiago, Chile"
                 fill
                 objectFit="cover"
                 className="shadow-[inset_0_0_60px_rgba(0,0,0,0.3)]"

--- a/app/seguridad-bodegas-logistica-chile/page.tsx
+++ b/app/seguridad-bodegas-logistica-chile/page.tsx
@@ -54,7 +54,7 @@ export default function SeguridadBodegasPage() {
 
       <section className="gard-hero min-h-[70vh] flex flex-col justify-center items-center relative overflow-hidden">
         <div className="absolute inset-0">
-          <CloudflareImage imageId="683f9081-3573-4e90-e733-5c1507350900" alt="Seguridad para bodegas logísticas Chile" fill className="object-cover" priority />
+          <CloudflareImage imageId="71e50080-0802-4f2c-ce4f-b34f56f22900" alt="Guardia Gard Security protegiendo bodega logística y centro de distribución en Chile" fill className="object-cover" priority />
           <div className="absolute inset-0 bg-black/60"></div>
         </div>
         

--- a/app/seguridad-construccion-santiago/page.tsx
+++ b/app/seguridad-construccion-santiago/page.tsx
@@ -54,8 +54,8 @@ export default function SeguridadConstruccionPage() {
       <section className="gard-hero min-h-[70vh] flex flex-col justify-center items-center relative overflow-hidden">
         <div className="absolute inset-0">
           <CloudflareImage
-            imageId="5b23cd4e-7e45-4f89-b234-8c1a3456ef00"
-            alt="Seguridad para construcción en Santiago"
+            imageId="1e7b161c-a76a-44bf-2a38-67b0631f8f00"
+            alt="Guardia Gard Security con chaleco reflectante en obra de construcción en Santiago"
             fill
             className="object-cover"
             priority

--- a/app/servicios/[slug]/page.tsx
+++ b/app/servicios/[slug]/page.tsx
@@ -27,6 +27,7 @@ import {
   Hotel
 } from 'lucide-react';
 import GaleriaImagenes from '@/components/GaleriaImagenes';
+import GuardiasEnAccion from '@/components/secciones/GuardiasEnAccion';
 import FormularioCotizacionSeccion from '@/app/components/FormularioCotizacionSeccion';
 import BreadcrumbSchema, { Breadcrumbs } from '@/components/seo/BreadcrumbSchema';
 import ServiceSchema from '@/components/seo/ServiceSchema';
@@ -257,7 +258,7 @@ export default async function ServicioPage({ params }: { params: Promise<{ slug:
         
         {/* Mostrar video o imagen dependiendo del servicio */}
         <div className="absolute inset-0 w-full h-full">
-          {(servicio.slug === 'auditoria-seguridad' || servicio.slug === 'consultoria') ? (
+          {(servicio.slug === 'auditoria-seguridad' || servicio.slug === 'consultoria' || servicio.slug === 'guardias-de-seguridad') ? (
             <CloudflareImage
               imageId={servicio.heroImageId}
               alt={`${servicio.name} - Gard Security`}
@@ -296,6 +297,9 @@ export default async function ServicioPage({ params }: { params: Promise<{ slug:
           </div>
         </section>
       )}
+
+      {/* Galería SEO-rica: guardias en acción (solo para el servicio de guardias) */}
+      {resolvedParams.slug === 'guardias-de-seguridad' && <GuardiasEnAccion />}
 
       {/* Industrias compatibles - Usamos el componente reutilizable */}
       <section className="gard-section py-16 md:py-24 bg-white dark:bg-[#0A0C12] relative">

--- a/components/secciones/GuardiasEnAccion.tsx
+++ b/components/secciones/GuardiasEnAccion.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import CloudflareImage from '@/components/CloudflareImage';
+import { cloudflareImages } from '@/lib/images';
+
+const FOTOS = [
+  {
+    id: cloudflareImages.guardias.equipoHome,
+    alt: 'Equipo de guardias de seguridad Gard Security certificados OS10 frente a edificio corporativo con bandera chilena en Santiago',
+  },
+  {
+    id: cloudflareImages.guardias.panoramico,
+    alt: 'Equipo Gard Security en institución patrimonial en Santiago, Chile',
+  },
+  {
+    id: cloudflareImages.guardias.lobbyPremium,
+    alt: 'Guardia Gard Security en recepción premium de edificio corporativo, con CCTV visible',
+  },
+  {
+    id: cloudflareImages.guardias.recepcionMujer,
+    alt: 'Guardia mujer Gard Security en recepción de edificio corporativo en Chile',
+  },
+  {
+    id: cloudflareImages.guardias.residencialGorra,
+    alt: 'Guardia Gard Security con gorra institucional en edificio residencial en Santiago',
+  },
+  {
+    id: cloudflareImages.guardias.industrialReflectante,
+    alt: 'Guardia Gard Security con chaleco reflectante en instalación industrial en Chile',
+  },
+  {
+    id: cloudflareImages.guardias.industrialGarita,
+    alt: 'Guardia Gard Security en garita de control de acceso de planta industrial / bodega logística',
+  },
+  {
+    id: cloudflareImages.guardias.accesoVehicular,
+    alt: 'Guardia Gard Security en control de acceso vehicular de estacionamiento corporativo',
+  },
+  {
+    id: cloudflareImages.guardias.logistica,
+    alt: 'Guardia Gard Security en exterior de centro logístico en Chile',
+  },
+  {
+    id: cloudflareImages.guardias.institucionalNorte,
+    alt: 'Guardia Gard Security en institución pública de la Región de Atacama, norte de Chile',
+  },
+];
+
+export default function GuardiasEnAccion() {
+  return (
+    <section
+      className="gard-section py-16 md:py-24 bg-[hsl(var(--gard-background))]"
+      aria-label="Guardias de seguridad Gard Security en acción"
+    >
+      <div className="gard-container">
+        <header className="max-w-3xl mx-auto text-center mb-10 md:mb-14">
+          <h2 className="text-heading-2 mb-4">Nuestros guardias en acción</h2>
+          <p className="text-body-lg text-muted-foreground">
+            Más de 1.000 guardias Gard Security certificados OS10 protegen empresas en 10 ciudades de Chile:
+            minería, logística, edificios corporativos, retail, construcción e instituciones públicas.
+          </p>
+        </header>
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3 md:gap-4">
+          {FOTOS.map((f, i) => (
+            <motion.div
+              key={f.id}
+              initial={{ opacity: 0, y: 16 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: '-50px' }}
+              transition={{ delay: i * 0.05, duration: 0.4 }}
+              className="relative aspect-[3/4] rounded-xl overflow-hidden shadow-md hover:shadow-xl transition-shadow"
+            >
+              <CloudflareImage
+                imageId={f.id}
+                alt={f.alt}
+                fill
+                objectFit="cover"
+                sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 20vw"
+              />
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/servicios/ServiciosLandingClient.tsx
+++ b/components/servicios/ServiciosLandingClient.tsx
@@ -23,7 +23,7 @@ export default function ServiciosLandingClient() {
         subtitle="Protección integral para industrias, empresas, instituciones y comunidades."
         ctaTexto="Cotiza ahora"
         ctaHref="#cotizar"
-        imageId="5eea1064-8a2d-4e8b-5606-d28775467a00"
+        imageId="4613e018-4925-4fb0-1fee-ed8ede43cd00"
         badge={{
           icon: <Shield className="h-4 w-4" />,
           text: "Servicios de Alta Calidad"

--- a/components/sobre-nosotros/SobreNosotrosClient.tsx
+++ b/components/sobre-nosotros/SobreNosotrosClient.tsx
@@ -38,7 +38,7 @@ export default function SobreNosotrosClient() {
       <GardHero 
         title="Somos Gard Security: tu socio en protección empresarial"
         subtitle="Equipo profesional resguardando instalaciones críticas, con tecnología avanzada y equipos altamente capacitados."
-        imageId="7d33f2ab-1ad7-4f8d-11c3-e82a0b54db00"
+        imageId="4613e018-4925-4fb0-1fee-ed8ede43cd00"
         badge={{
           icon: <Shield className="h-4 w-4" />,
           text: "Líderes en Seguridad"
@@ -121,7 +121,7 @@ export default function SobreNosotrosClient() {
             <div className="relative h-[300px] md:h-full rounded-xl overflow-hidden shadow-md">
               <div className="absolute inset-0 bg-gradient-to-tr from-black/40 to-transparent z-10"></div>
               <CloudflareImage
-                imageId="7d33f2ab-1ad7-4f8d-11c3-e82a0b54db00"
+                imageId="4613e018-4925-4fb0-1fee-ed8ede43cd00"
                 alt="Trayectoria de Gard Security"
                 fill
                 className="object-cover"

--- a/lib/blog-og-image.ts
+++ b/lib/blog-og-image.ts
@@ -1,7 +1,7 @@
 import { CLOUDFLARE_ACCOUNT_HASH } from '@/lib/images';
 
 const SITE_ORIGIN = 'https://www.gard.cl';
-const DEFAULT_CLOUDFLARE_IMAGE_ID = '5eea1064-8a2d-4e8b-5606-d28775467a00';
+const DEFAULT_CLOUDFLARE_IMAGE_ID = '4613e018-4925-4fb0-1fee-ed8ede43cd00';
 
 function isValidCloudflareImageId(id: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(id);

--- a/lib/data/getCiudadServicioContent.ts
+++ b/lib/data/getCiudadServicioContent.ts
@@ -313,7 +313,7 @@ const getRandomSecurityFeature = (servicioNombre: string): string => {
  */
 const getImageIdByService = (servicioSlug: string): string => {
   const imageIds: Record<string, string> = {
-    'guardias-de-seguridad': '5eea1064-8a2d-4e8b-5606-d28775467a00',
+    'guardias-de-seguridad': '4613e018-4925-4fb0-1fee-ed8ede43cd00',
     'seguridad-electronica': '678cad4f-9b0d-49e6-3bbd-0d747a2fdc00',
     'central-monitoreo': '5c97d40c-bf3c-4413-6ead-c15f7c9aa100',
     'drones-seguridad': '5c97d40c-bf3c-4413-6ead-c15f7c9aa100',
@@ -323,5 +323,5 @@ const getImageIdByService = (servicioSlug: string): string => {
     'prevencion-intrusiones': 'eeaf472c-ab11-448b-f5e2-d18415147800'
   };
   
-  return imageIds[servicioSlug] || '5eea1064-8a2d-4e8b-5606-d28775467a00';
+  return imageIds[servicioSlug] || '4613e018-4925-4fb0-1fee-ed8ede43cd00';
 }; 

--- a/lib/data/getServicioIndustriaContent.ts
+++ b/lib/data/getServicioIndustriaContent.ts
@@ -110,7 +110,7 @@ export const getServicioIndustriaContent = (
       ctaTexto: `Solicitar ${servicioBase} para ${nombreIndustria}`,
       imageId: industria.slug === 'mineria' ? '7d33f2ab-1ad7-4f8d-11c3-e82a0b54db00' : 
                industria.slug === 'retail' ? 'bee9d371-805c-4029-59f6-93cdfd916000' : 
-               '5eea1064-8a2d-4e8b-5606-d28775467a00'
+               '4613e018-4925-4fb0-1fee-ed8ede43cd00'
     };
   }
 };

--- a/lib/data/landingText.ts
+++ b/lib/data/landingText.ts
@@ -59,7 +59,7 @@ const serviciosGenericos: { [key: string]: TextContent } = {
       }
     ],
     ctaText: 'Solicitar guardia privado',
-    imageId: '5eea1064-8a2d-4e8b-5606-d28775467a00'
+    imageId: '4613e018-4925-4fb0-1fee-ed8ede43cd00'
   },
   'camaras-seguridad': {
     title: 'Cámaras de Seguridad',

--- a/lib/images.ts
+++ b/lib/images.ts
@@ -21,7 +21,7 @@ export const cloudflareImages = {
   hero: {
     home: '4824f8b9-abb0-4e77-c654-efe920697b00',
     about: '7d33f2ab-1ad7-4f8d-11c3-e82a0b54db00',
-    services: '5eea1064-8a2d-4e8b-5606-d28775467a00',
+    services: '4613e018-4925-4fb0-1fee-ed8ede43cd00',
     contact: '428c1028-8f6b-455a-e110-38421eeb5700',
     reclutamiento: '4a46b63d-0e1b-4640-b95c-7f040a288c00',
   },
@@ -29,9 +29,9 @@ export const cloudflareImages = {
   // Imágenes para secciones
   sections: {
     about: '7d33f2ab-1ad7-4f8d-11c3-e82a0b54db00',
-    services: '5eea1064-8a2d-4e8b-5606-d28775467a00',
+    services: '4613e018-4925-4fb0-1fee-ed8ede43cd00',
     technologies: '678cad4f-9b0d-49e6-3bbd-0d747a2fdc00',
-    team: '7d33f2ab-1ad7-4f8d-11c3-e82a0b54db00',
+    team: '57d32c87-0757-48e9-747f-2f7e66737100',
   },
   
   // Iconos de servicios y características
@@ -46,10 +46,24 @@ export const cloudflareImages = {
   
   // Equipo
   team: {
-    ceo: '7d33f2ab-1ad7-4f8d-11c3-e82a0b54db00',
-    cto: '7d33f2ab-1ad7-4f8d-11c3-e82a0b54db00',
-    security: '7d33f2ab-1ad7-4f8d-11c3-e82a0b54db00',
-    support: '7d33f2ab-1ad7-4f8d-11c3-e82a0b54db00',
+    ceo: '57d32c87-0757-48e9-747f-2f7e66737100',
+    cto: '57d32c87-0757-48e9-747f-2f7e66737100',
+    security: '57d32c87-0757-48e9-747f-2f7e66737100',
+    support: '57d32c87-0757-48e9-747f-2f7e66737100',
+  },
+
+  // Fotos reales de guardias Gard (abril 2026) — fuente: scripts/guardias-fotos-ids.json
+  guardias: {
+    equipoHome: '57d32c87-0757-48e9-747f-2f7e66737100',                    // Home hero + Empresas (3 guardias bandera)
+    panoramico: '4613e018-4925-4fb0-1fee-ed8ede43cd00',                    // Banner hero / Sobre Nosotros (edif. patrimonial)
+    logistica: '71e50080-0802-4f2c-ce4f-b34f56f22900',                     // Bodegas / logística
+    recepcionMujer: 'b0818218-7e38-4d9b-6dcf-5538e24b4e00',                // Edificios corporativos (mujer)
+    accesoVehicular: '2539041c-4815-4194-1656-fa6993014200',               // Control acceso vehicular
+    industrialReflectante: '1e7b161c-a76a-44bf-2a38-67b0631f8f00',         // Construcción / retail industrial
+    residencialGorra: '0b92cbb0-137d-45a1-eda4-94c70eff7600',              // Condominios / edificios
+    lobbyPremium: 'a89d3b2e-9738-4c67-c34f-3682a516c800',                  // Edificios corporativos premium
+    institucionalNorte: '22439039-6cb0-4ed4-a362-5aebe3ffaa00',            // Antofagasta / gobierno
+    industrialGarita: '29d16f73-5388-479a-a0ad-84774cbce300',              // Minería / bodegas industriales
   },
   
   // Clientes y marcas

--- a/scripts/guardias-fotos-ids.json
+++ b/scripts/guardias-fotos-ids.json
@@ -1,0 +1,12 @@
+{
+  "guardia_logistica": "71e50080-0802-4f2c-ce4f-b34f56f22900",
+  "equipo_home": "57d32c87-0757-48e9-747f-2f7e66737100",
+  "recepcion_mujer": "b0818218-7e38-4d9b-6dcf-5538e24b4e00",
+  "panoramico_patrimonial": "4613e018-4925-4fb0-1fee-ed8ede43cd00",
+  "acceso_vehicular": "2539041c-4815-4194-1656-fa6993014200",
+  "industrial_reflectante": "1e7b161c-a76a-44bf-2a38-67b0631f8f00",
+  "residencial_gorra": "0b92cbb0-137d-45a1-eda4-94c70eff7600",
+  "lobby_premium": "a89d3b2e-9738-4c67-c34f-3682a516c800",
+  "institucional_norte": "22439039-6cb0-4ed4-a362-5aebe3ffaa00",
+  "industrial_garita": "29d16f73-5388-479a-a0ad-84774cbce300"
+}

--- a/scripts/upload-guardias-fotos-cloudflare.sh
+++ b/scripts/upload-guardias-fotos-cloudflare.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Script para subir las 10 fotos reales de guardias Gard (abril 2026) a Cloudflare Images.
+# Requiere: CLOUDFLARE_API_TOKEN con permiso "Images Edit".
+# Account ID: e56e6231ebbfb3edd31e85df0a7092bc
+#
+# Genera: scripts/guardias-fotos-ids.json con el mapping clave_logica -> cloudflare_id.
+
+set -u
+
+ACCOUNT_ID="e56e6231ebbfb3edd31e85df0a7092bc"
+API_URL="https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/images/v1"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+OUT_JSON="${SCRIPT_DIR}/guardias-fotos-ids.json"
+
+if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] && [ -f "${PROJECT_ROOT}/.env.local" ]; then
+  TOKEN_LINE=$(grep -E '^CLOUDFLARE_API_TOKEN=' "${PROJECT_ROOT}/.env.local" | head -1 | cut -d'=' -f2-)
+  if [ -n "$TOKEN_LINE" ]; then
+    export CLOUDFLARE_API_TOKEN="$TOKEN_LINE"
+    echo "Token cargado desde .env.local"
+  fi
+fi
+
+if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+  echo "Error: Define CLOUDFLARE_API_TOKEN con permiso 'Images Edit'."
+  echo "Crea el token en https://dash.cloudflare.com/profile/api-tokens"
+  exit 1
+fi
+
+SRC_DIR="/Users/caco/Library/CloudStorage/GoogleDrive-carlos.irigoyen@gard.cl/Mi unidad/Marketing/Foto Guardias"
+
+# orden | archivo_local | nombre_cloudflare | clave_logica
+MAPPING=(
+  "Cambio de imagen Abr 23 2026 (6).png|guardia-hombre-bodega-logistica|guardia_logistica"
+  "Cambio de imagen abr 23 2026 (7).png|equipo-guardias-bandera-chilena-corporativo|equipo_home"
+  "Cambio de imagen abr 23 2026 (8).png|guardia-mujer-recepcion-corporativo|recepcion_mujer"
+  "Cambio de imagen abr 23 2026 (9).png|equipo-guardias-edificio-patrimonial-panoramico|panoramico_patrimonial"
+  "Cambio de imagen abr 23 2026 (10).png|guardia-mujer-garita-acceso-vehicular|acceso_vehicular"
+  "Cambio de imagen abr 23 2026 (11).png|guardia-mujer-chaleco-reflectante-industrial|industrial_reflectante"
+  "Cambio de imagen abr 23 2026 (12).png|guardia-hombre-gorra-edificio-residencial|residencial_gorra"
+  "ChatGPT Imagen Abr 23 2026 Edición UI (1).png|guardia-recepcion-lobby-premium-cctv|lobby_premium"
+  "ChatGPT Imagen Abr 23 2026 Edición UI (2).png|guardia-institucional-atacama-norte|institucional_norte"
+  "ChatGPT Imagen Abr 23 2026 Edición UI.png|guardia-mujer-garita-industrial-barrera|industrial_garita"
+)
+
+parse_id() {
+  local json="$1"
+  if command -v node &>/dev/null; then
+    printf '%s' "$json" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const j=JSON.parse(d);console.log(j.success&&j.result?j.result.id:'')}catch(e){console.log('')}});"
+  else
+    printf '%s' "$json" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4
+  fi
+}
+
+upload_one() {
+  local file_path="$1"
+  local cf_name="$2"
+  local attempt=1
+  local max=3
+  local resp=""
+  while [ $attempt -le $max ]; do
+    resp=$(curl -sS -X POST "$API_URL" \
+      -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+      -F "file=@${file_path}" \
+      -F "metadata={\"name\":\"${cf_name}\"}")
+    local id
+    id=$(parse_id "$resp")
+    if [ -n "$id" ]; then
+      echo "$id"
+      return 0
+    fi
+    echo "  [intento $attempt] fallo subir '${cf_name}': $resp" >&2
+    attempt=$((attempt+1))
+    sleep 1
+  done
+  return 1
+}
+
+echo "Subiendo 10 fotos de guardias a Cloudflare Images..."
+echo "Directorio origen: $SRC_DIR"
+echo ""
+
+declare -a KEYS
+declare -a IDS
+
+for entry in "${MAPPING[@]}"; do
+  IFS='|' read -r FILENAME CF_NAME LOGIC_KEY <<< "$entry"
+  FULL_PATH="${SRC_DIR}/${FILENAME}"
+  if [ ! -f "$FULL_PATH" ]; then
+    echo "Error: no existe el archivo '${FULL_PATH}'" >&2
+    exit 1
+  fi
+  echo "-> ${LOGIC_KEY} (${FILENAME})"
+  CF_ID=$(upload_one "$FULL_PATH" "$CF_NAME") || {
+    echo "Upload falló para ${LOGIC_KEY}. Deteniendo." >&2
+    exit 1
+  }
+  echo "   id: $CF_ID"
+  KEYS+=("$LOGIC_KEY")
+  IDS+=("$CF_ID")
+done
+
+echo ""
+echo "Escribiendo ${OUT_JSON}..."
+{
+  echo "{"
+  for i in "${!KEYS[@]}"; do
+    SEP=","
+    if [ "$i" -eq $(( ${#KEYS[@]} - 1 )) ]; then SEP=""; fi
+    printf '  "%s": "%s"%s\n' "${KEYS[$i]}" "${IDS[$i]}" "$SEP"
+  done
+  echo "}"
+} > "$OUT_JSON"
+
+echo ""
+echo "✅ Listo. Mapping guardado en: ${OUT_JSON}"
+cat "$OUT_JSON"


### PR DESCRIPTION
…d 2026

- Sube 10 fotos reales de guardias Gard Security a Cloudflare Images
- Centraliza IDs en lib/images.ts -> cloudflareImages.guardias
- Reemplaza IDs obsoletos en servicios, ciudades, industrias y landings
- Agrega componente GuardiasEnAccion con galería SEO-optimizada
- Integra galería en /servicios/guardias-de-seguridad y /guardias-de-seguridad-privada-para-empresas
- Añade hero image a página B2B principal (antes sin imágenes)
- Alt-text SEO-rich: OS10, Chile, ciudades y escenarios específicos

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily swaps Cloudflare image IDs/alt text across marketing pages and adds a new client-side photo gallery section; main impact is on page rendering/performance if any image IDs are wrong or the new `framer-motion` section affects load.
> 
> **Overview**
> Replaces stock guard imagery across key landing/service/city pages with a new set of *real* guard photos, updating Cloudflare image IDs and SEO-focused `alt` text throughout.
> 
> Centralizes the new photo IDs under `cloudflareImages.guardias` (plus a mapping JSON + upload script), adds a new client component `GuardiasEnAccion` (animated image grid), and embeds it into the guard service pages (including making `guardias-de-seguridad` use a hero image instead of video and adding a new hero banner on the B2B guards page).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b4fc3c70e102f655594a9643d36520b237e669c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->