### PR TITLE
feat(cotizar): trust signals + cleanup payload zombie (Sprint 1A)

### DIFF
--- a/app/components/cotizador/CotizadorInteligenteV2.tsx
+++ b/app/components/cotizador/CotizadorInteligenteV2.tsx
@@ -29,7 +29,10 @@ import {
   MapPin,
   X,
   Check,
-  MessageCircle
+  MessageCircle,
+  ShieldCheck,
+  Zap,
+  Lock
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
@@ -778,7 +781,7 @@ export default function CotizadorInteligenteV2() {
                 <Send className="h-4 w-4" />
                 <span>Solicitar Cotización</span>
               </button>
-              <p className="text-xs text-muted-foreground mt-3">Responderemos en menos de 24 horas.</p>
+              <p className="text-xs text-muted-foreground mt-3">Te contactaremos en los próximos minutos en horario hábil.</p>
             </div>
           </motion.div>
           
@@ -998,6 +1001,21 @@ export default function CotizadorInteligenteV2() {
                       {formErrors.comentarios && <p className="text-red-500 text-xs mt-1">{formErrors.comentarios}</p>}
                     </div>
                     
+                    <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 py-3 mb-1 text-xs text-muted-foreground border-y border-border/50">
+                      <span className="inline-flex items-center gap-1.5">
+                        <ShieldCheck className="h-4 w-4 text-emerald-600" />
+                        <span>OS-10 Certificados</span>
+                      </span>
+                      <span className="inline-flex items-center gap-1.5">
+                        <Zap className="h-4 w-4 text-amber-500" />
+                        <span>Respuesta en menos de 5 min</span>
+                      </span>
+                      <span className="inline-flex items-center gap-1.5">
+                        <Lock className="h-4 w-4 text-blue-600" />
+                        <span>Sin compromiso</span>
+                      </span>
+                    </div>
+
                     <div className="flex justify-end gap-3 pt-2">
                       <Button type="button" variant="outline" onClick={() => setShowForm(false)}>Cancelar</Button>
                       <Button type="submit" disabled={isSubmitting}>

--- a/app/cotizar/components/CotizacionForm.tsx
+++ b/app/cotizar/components/CotizacionForm.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useRef, useCallback, RefCallback } from 're
 import { useForm, useFieldArray } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
-import { Loader2, Plus, Trash2, Shield, MessageCircle, ArrowLeft } from 'lucide-react';
+import { Loader2, Plus, Trash2, Shield, ShieldCheck, MessageCircle, ArrowLeft, Zap, Lock } from 'lucide-react';
 import DotacionQuickBuilder, {
   type QuickPuesto,
   buildDotacion,
@@ -119,29 +119,6 @@ const OPAI_URL = process.env.NEXT_PUBLIC_OPAI_API_URL || 'https://opai.gard.cl';
 function buildWhatsAppCotizacionMessage(nombre: string, apellido: string, empresa: string, detalle?: string): string {
   const base = `Hola, ${nombre}. Soy ${nombre} ${apellido} de ${empresa}. Te envío una cotización y el detalle de la cotización.`;
   return detalle?.trim() ? `${base}\n\n${detalle.trim()}` : base;
-}
-
-// Mensaje para el link de WhatsApp en el email a comercial@gard.cl (para que comercial le escriba al cliente)
-function buildWhatsAppComercialToClientMessage(
-  nombreCliente: string,
-  empresa: string,
-  direccion: string,
-  comuna: string,
-  ciudad: string,
-  servicioRequerido: string,
-  dotacion: Array<{ puesto: string; cantidad: number }> | undefined,
-  detalleCotizacion: string
-): string {
-  const ubicacion = [direccion, comuna, ciudad].filter(Boolean).join(', ') || direccion;
-  let consisteEn: string;
-  if (dotacion && dotacion.length > 0) {
-    const partes = dotacion.map((d) => `${d.cantidad} puesto${d.cantidad !== 1 ? 's' : ''} de ${d.puesto}`);
-    consisteEn = partes.join(', ');
-    if (detalleCotizacion?.trim()) consisteEn += `. ${detalleCotizacion.trim()}`;
-  } else {
-    consisteEn = detalleCotizacion?.trim() || servicioRequerido;
-  }
-  return `Hola ${nombreCliente}, te contacto de gard.cl. Nos enviaste una cotización para la empresa ${empresa}, ubicada en ${ubicacion}, que consiste en ${consisteEn}.`;
 }
 
 export default function CotizacionForm({ prefillServicio, prefillIndustria }: CotizacionFormProps = {}) {
@@ -479,26 +456,6 @@ export default function CotizacionForm({ prefillServicio, prefillIndustria }: Co
     try {
       setIsSubmitting(true);
       
-      // Mensaje para WhatsApp (botón del modal y link en el email al cliente)
-      const whatsappMessage = buildWhatsAppCotizacionMessage(
-        data.nombre,
-        data.apellido,
-        data.empresa,
-        data.cotizacion || ''
-      );
-
-      // Mensaje para el link de WhatsApp en el email a comercial@gard.cl (para responder al cliente)
-      const whatsappComercialToClient = buildWhatsAppComercialToClientMessage(
-        data.nombre,
-        data.empresa,
-        data.direccion,
-        data.comuna || '',
-        data.ciudad || '',
-        data.servicioRequerido,
-        data.dotacion?.map((d) => ({ puesto: d.puesto, cantidad: d.cantidad })),
-        data.cotizacion || ''
-      );
-
       const detalleCompleto = (data.cotizacion || '') + (data.utm_source ? `\n\n[UTM: ${data.utm_source}/${data.utm_medium}/${data.utm_campaign}]` : '');
       const detalleTruncado = detalleCompleto.length > 5000 ? detalleCompleto.slice(0, 4997) + '...' : detalleCompleto;
 
@@ -536,8 +493,6 @@ export default function CotizacionForm({ prefillServicio, prefillIndustria }: Co
         detalle: detalleTruncado,
         dotacion: dotacionOpai,
         source: 'web_cotizador' as const,
-        whatsapp_prefilled_message: whatsappMessage,
-        whatsapp_message_comercial_to_cliente: whatsappComercialToClient,
       };
       
       // Enviar a OPAI con retry automático (hasta 2 reintentos)
@@ -1000,6 +955,22 @@ export default function CotizacionForm({ prefillServicio, prefillIndustria }: Co
               </div>
             )}
 
+            {/* ── Trust signals ── */}
+            <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 py-3 mb-3 text-xs text-muted-foreground border-y border-border/50">
+              <span className="inline-flex items-center gap-1.5">
+                <ShieldCheck className="h-4 w-4 text-emerald-600" />
+                <span>OS-10 Certificados</span>
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Zap className="h-4 w-4 text-amber-500" />
+                <span>Respuesta en menos de 5 min</span>
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Lock className="h-4 w-4 text-blue-600" />
+                <span>Sin compromiso</span>
+              </span>
+            </div>
+
             {/* ── Submit ── */}
             <Button type="submit" disabled={isSubmitting} variant="default" size="lg" className="w-full md:w-auto rounded-2xl">
               {isSubmitting ? (
@@ -1008,6 +979,10 @@ export default function CotizacionForm({ prefillServicio, prefillIndustria }: Co
                 "Enviar Cotización"
               )}
             </Button>
+            <p className="text-center text-xs text-muted-foreground mt-3 leading-relaxed">
+              Al enviar no te llamamos hasta que confirmes. Tus datos se manejan según nuestra{' '}
+              <a href="/privacidad" className="underline hover:text-foreground">política de privacidad</a>.
+            </p>
           </form>
         </Form>
       )}


### PR DESCRIPTION
## Resumen

Sprint 1A del plan de optimización del flujo de cotización: refuerzo visual de credibilidad en el momento de máxima fricción y limpieza de código muerto. **Sin cambios de lógica de negocio, validaciones ni endpoints.**

## Cambios

### `app/cotizar/components/CotizacionForm.tsx`
- **Trust signals** (OS-10 Certificados · Respuesta <5 min · Sin compromiso) inmediatamente arriba del botón submit.
- **Disclaimer** reasegurador debajo del submit con link a `/privacidad`.
- **Cleanup payload OPAI**: removidos `whatsapp_prefilled_message` y `whatsapp_message_comercial_to_cliente` (el backend OPAI los descartaba silenciosamente — no están en su schema Zod).
- **Cleanup huérfanos**: eliminados los consts `whatsappMessage` y `whatsappComercialToClient` y la función `buildWhatsAppComercialToClientMessage` que solo alimentaban los campos zombie.
- **Conservada** la función `buildWhatsAppCotizacionMessage` porque sigue usándose en el modal de éxito post-submit (botón de WhatsApp).

### `app/components/cotizador/CotizadorInteligenteV2.tsx`
- Mismo bloque de trust signals dentro del form modal de captura de datos.
- Copy ajustado: _"Responderemos en menos de 24 horas."_ → _"Te contactaremos en los próximos minutos en horario hábil."_
- Las menciones técnicas restantes de "24 horas" (tipo de turno) se mantienen — son etiquetas funcionales, no copy.

## Diff stats

```
app/components/cotizador/CotizadorInteligenteV2.tsx | 22 ++++++-
app/cotizar/components/CotizacionForm.tsx           | 67 +++++++---------------
2 files changed, 41 insertions(+), 48 deletions(-)
```

## Test plan

- [x] `npm run build` pasa sin errores ni warnings.
- [x] `/cotizar` responde 200 con los 3 trust signals + disclaimer en el HTML inicial.
- [x] `/cotizador-inteligente` responde 200 con el copy actualizado.
- [ ] **Verificación manual en browser** (queda al revisor):
  - [ ] `/cotizar` muestra los 3 badges arriba del submit y el disclaimer debajo.
  - [ ] Submit del formulario sigue funcionando y el lead llega a OPAI.
  - [ ] `/cotizador-inteligente` → al abrir el modal de captura se ven los 3 badges.
  - [ ] Mobile (375px) los badges hacen wrap correctamente.

## Riesgo

Bajo. Cambios visuales + cleanup. La validación zod, el endpoint y la lógica de envío quedan intactos.

## Próximo paso

Una vez mergeado este PR, queda habilitado Sprint 1B (multi-step gamificado) que depende de él.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily UI copy/UX additions and removal of unused payload fields; submission flow and endpoints remain unchanged but should be spot-checked to ensure no downstream dependency on the removed fields.
> 
> **Overview**
> Adds *trust-signal* badges (OS-10, <5 min response, no commitment) to both the `/cotizar` form and the `CotizadorInteligenteV2` modal to reduce friction near submission, plus a small reassurance/privacy disclaimer under the `/cotizar` submit button.
> 
> Cleans up the `/cotizar` submission payload by removing previously-sent WhatsApp message fields and their now-dead helper code, and updates the cotizador CTA copy from “<24 horas” to “próximos minutos en horario hábil.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0a9783d89c5e3272fe98734e51daec5316eb230. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->