### PR TITLE
fix(cotizar): trust signal "5 min" → "1 hora"

### DIFF
--- a/app/components/cotizador/CotizadorInteligenteV2.tsx
+++ b/app/components/cotizador/CotizadorInteligenteV2.tsx
@@ -1008,7 +1008,7 @@ export default function CotizadorInteligenteV2() {
                       </span>
                       <span className="inline-flex items-center gap-1.5">
                         <Zap className="h-4 w-4 text-amber-500" />
-                        <span>Respuesta en menos de 5 min</span>
+                        <span>Respuesta en menos de 1 hora</span>
                       </span>
                       <span className="inline-flex items-center gap-1.5">
                         <Lock className="h-4 w-4 text-blue-600" />

--- a/app/cotizar/components/CotizacionForm.tsx
+++ b/app/cotizar/components/CotizacionForm.tsx
@@ -963,7 +963,7 @@ export default function CotizacionForm({ prefillServicio, prefillIndustria }: Co
               </span>
               <span className="inline-flex items-center gap-1.5">
                 <Zap className="h-4 w-4 text-amber-500" />
-                <span>Respuesta en menos de 5 min</span>
+                <span>Respuesta en menos de 1 hora</span>
               </span>
               <span className="inline-flex items-center gap-1.5">
                 <Lock className="h-4 w-4 text-blue-600" />


### PR DESCRIPTION
## Resumen

Ajuste de copy del trust signal introducido en Sprint 1A. La promesa de "menos de 5 min" era demasiado agresiva e irrealista; "menos de 1 hora" mantiene sentido de urgencia siendo realmente alcanzable por el equipo comercial.

## Cambios

- [app/cotizar/components/CotizacionForm.tsx](app/cotizar/components/CotizacionForm.tsx) — trust signal del submit.
- [app/components/cotizador/CotizadorInteligenteV2.tsx](app/components/cotizador/CotizadorInteligenteV2.tsx) — trust signal del modal de captura.

## Notas

- El sprint 1B (PR #26) tiene el mismo trust signal en `CotizacionFormMultiStep.tsx`. Ese cambio se aplicará como follow-up commit al PR #26 para mantener ambas variantes consistentes.
- Otras menciones a "12 horas hábiles" en el sitio (sidebars, FAQ, meta descriptions) quedan intactas — son decisión de copy más amplia, fuera de scope de esta corrección.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change in two UI components; no logic, data handling, or API behavior is modified.
> 
> **Overview**
> Updates the quote-request *trust signal* copy from `Respuesta en menos de 5 min` to `Respuesta en menos de 1 hora` in both `CotizacionForm` and the `CotizadorInteligenteV2` modal so the displayed response-time promise is consistent and less aggressive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e5815b8fe11084ccd9fe0bd2ed754428ca09b61. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->