### PR TITLE
feat(cotizar): captura progresiva + exit-intent popup (Sprint 2)

### DIFF
--- a/app/cotizar/components/CotizacionFormMultiStep.tsx
+++ b/app/cotizar/components/CotizacionFormMultiStep.tsx
@@ -87,6 +87,60 @@ type FormValues = z.infer<typeof formSchema>;
 
 const OPAI_URL = process.env.NEXT_PUBLIC_OPAI_API_URL || 'https://opai.gard.cl';
 
+// ─────────── Captura progresiva (partial_lead en localStorage) ───────────
+
+const PARTIAL_LEAD_KEY = 'gard_partial_lead_v1';
+const PARTIAL_LEAD_TTL_MS = 24 * 60 * 60 * 1000;
+
+type PartialLeadSelections = {
+  industriaId: string;
+  industriaValue: string;
+  cobertura: string;
+  cantidadId: string;
+  cantidad: number;
+  needsHelpCantidad: boolean;
+};
+
+type PartialLead = {
+  selections: PartialLeadSelections;
+  timestamp: number;
+};
+
+function savePartialLead(selections: PartialLeadSelections) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(PARTIAL_LEAD_KEY, JSON.stringify({ selections, timestamp: Date.now() }));
+  } catch {
+    // localStorage puede estar bloqueado (modo incógnito + cookies bloqueadas) — ignorar
+  }
+}
+
+function getPartialLead(): PartialLead | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(PARTIAL_LEAD_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PartialLead;
+    if (!parsed?.selections || typeof parsed.timestamp !== 'number') return null;
+    if (Date.now() - parsed.timestamp > PARTIAL_LEAD_TTL_MS) {
+      localStorage.removeItem(PARTIAL_LEAD_KEY);
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function clearPartialLead() {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(PARTIAL_LEAD_KEY);
+  } catch {
+    // ignorar
+  }
+}
+
 function buildWhatsAppCotizacionMessage(nombre: string, apellido: string, empresa: string, detalle?: string): string {
   const base = `Hola, ${nombre}. Soy ${nombre} ${apellido} de ${empresa}. Te envío una cotización y el detalle de la cotización.`;
   return detalle?.trim() ? `${base}\n\n${detalle.trim()}` : base;
@@ -303,6 +357,7 @@ export default function CotizacionFormMultiStep({ prefillServicio, prefillIndust
   const [lastSuccessData, setLastSuccessData] = useState<{ nombre: string; apellido: string; empresa: string; cotizacion: string } | null>(null);
   const autocompleteInputRef = useRef<HTMLInputElement | null>(null);
   const [mapLoaded, setMapLoaded] = useState(false);
+  const [partialLead, setPartialLead] = useState<PartialLead | null>(null);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -369,6 +424,25 @@ export default function CotizacionFormMultiStep({ prefillServicio, prefillIndust
   useEffect(() => {
     trackStep(currentStep, 'exposure');
   }, [currentStep]);
+
+  // Detectar partial lead pendiente al montar
+  useEffect(() => {
+    const pending = getPartialLead();
+    if (pending) {
+      setPartialLead(pending);
+      if (typeof window !== 'undefined') {
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({ event: 'cotiz_partial_lead_detected', variant: 'multistep' });
+      }
+    }
+  }, []);
+
+  // Persistir selecciones al llegar al paso 4 (antes de capturar datos personales)
+  useEffect(() => {
+    if (currentStep !== 4) return;
+    if (!selections.industriaValue) return;
+    savePartialLead(selections);
+  }, [currentStep, selections]);
 
   // Google Maps loader (solo cuando se llega a step 4)
   useEffect(() => {
@@ -523,6 +597,8 @@ export default function CotizacionFormMultiStep({ prefillServicio, prefillIndust
             });
             setFormStatus('success');
             form.reset();
+            clearPartialLead();
+            setPartialLead(null);
             sessionStorage.removeItem('user_service');
             sessionStorage.removeItem('user_industry');
             trackFormSubmission({
@@ -576,6 +652,36 @@ export default function CotizacionFormMultiStep({ prefillServicio, prefillIndust
     setDirection(1);
   };
 
+  const resumePartialLead = () => {
+    if (!partialLead) return;
+    const s = partialLead.selections;
+    setSelections({
+      industriaId: s.industriaId,
+      industriaValue: s.industriaValue,
+      cobertura: (s.cobertura as CoberturaId) || '',
+      cantidadId: s.cantidadId,
+      cantidad: s.cantidad,
+      needsHelpCantidad: s.needsHelpCantidad,
+    });
+    setValue('tipoIndustria', s.industriaValue);
+    setPartialLead(null);
+    setDirection(1);
+    setCurrentStep(4);
+    if (typeof window !== 'undefined') {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({ event: 'cotiz_partial_lead_resumed', variant: 'multistep' });
+    }
+  };
+
+  const dismissPartialLead = () => {
+    clearPartialLead();
+    setPartialLead(null);
+    if (typeof window !== 'undefined') {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({ event: 'cotiz_partial_lead_dismissed', variant: 'multistep' });
+    }
+  };
+
   if (formStatus === 'success') {
     return (
       <div className="bg-card rounded-xl shadow-sm p-6 md:p-8 border border-gray-200 dark:border-gray-700">
@@ -612,6 +718,33 @@ export default function CotizacionFormMultiStep({ prefillServicio, prefillIndust
 
   return (
     <div className="bg-card rounded-xl shadow-sm p-6 md:p-8 border border-gray-200 dark:border-gray-700">
+      <AnimatePresence>
+        {partialLead && (
+          <motion.div
+            key="partial-lead-banner"
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.3 }}
+            className="mb-5 p-4 rounded-xl border border-amber-200 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-700"
+          >
+            <p className="text-sm text-amber-900 dark:text-amber-200 mb-3">
+              👋 Te quedaste en una cotización
+              {partialLead.selections.industriaValue ? <> para <strong>{partialLead.selections.industriaValue}</strong></> : null}
+              . ¿Continuamos donde lo dejaste?
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" size="sm" onClick={resumePartialLead} className="rounded-xl">
+                Sí, continuar
+              </Button>
+              <Button type="button" size="sm" variant="outline" onClick={dismissPartialLead} className="rounded-xl">
+                Empezar de cero
+              </Button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       <ProgressBar current={currentStep} total={4} label={STEP_LABELS[currentStep - 1]} />
 
       <AnimatePresence mode="wait" custom={direction} initial={false}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import ClientScripts from './components/ClientScripts';
 import ClientWrapper from './ClientWrapper';
 import { metadata } from './metadata';
 import LocalBusinessSchema from '@/components/seo/LocalBusinessSchema';
+import ExitIntentPopup from '@/components/ExitIntentPopup';
 
 // Obtener GTM ID desde variables de entorno
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID || '';
@@ -76,6 +77,7 @@ export default function RootLayout({
             <main id="main-content" className="flex-grow">
               {children}
             </main>
+            <ExitIntentPopup />
             <Footer />
             <SpeedInsights />
             <Analytics />

--- a/components/ExitIntentPopup.tsx
+++ b/components/ExitIntentPopup.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+// Exit-intent popup — Sprint 2.
+// Detecta cuando el cursor sale por arriba del viewport (intent de cerrar
+// pestaña / ir atrás) en páginas de servicios/ciudades/industrias y ofrece
+// recuperar al usuario hacia /cotizar?v=multistep.
+//
+// Reglas:
+// - Solo desktop (>= 768px).
+// - Una vez por sesión (sessionStorage).
+// - Solo después de 15s en la página (evita falsos positivos al entrar).
+// - No se muestra en /cotizar, /cotizador-inteligente, /portal-cliente,
+//   /reclutamiento, /admin (paths donde el usuario ya está en flujo de
+//   conversión o no es target).
+
+import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { motion, AnimatePresence } from 'framer-motion';
+import Link from 'next/link';
+import { ShieldCheck, Zap, Lock, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const SESSION_KEY = 'gard_exit_popup_shown';
+const MIN_TIME_ON_PAGE_MS = 15_000;
+const NEVER_SHOW_PREFIXES = ['/cotizar', '/cotizador-inteligente', '/portal-cliente', '/reclutamiento', '/admin'];
+
+function shouldShowOnPath(pathname: string | null): boolean {
+  if (!pathname) return false;
+  return !NEVER_SHOW_PREFIXES.some((p) => pathname.startsWith(p));
+}
+
+function track(event: string, pathname: string | null) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ event, page_path: pathname || '' });
+  } catch {
+    // tracking no debe romper el render
+  }
+}
+
+export default function ExitIntentPopup() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const eligible = shouldShowOnPath(pathname);
+
+  useEffect(() => {
+    if (!eligible) return;
+    if (typeof window === 'undefined') return;
+    if (window.innerWidth < 768) return;
+    if (sessionStorage.getItem(SESSION_KEY) === '1') return;
+
+    const startedAt = Date.now();
+
+    const onMouseLeave = (e: MouseEvent) => {
+      if (e.clientY > 10) return;
+      if (Date.now() - startedAt < MIN_TIME_ON_PAGE_MS) return;
+      if (sessionStorage.getItem(SESSION_KEY) === '1') return;
+      sessionStorage.setItem(SESSION_KEY, '1');
+      setOpen(true);
+      track('exit_intent_shown', pathname);
+    };
+
+    document.addEventListener('mouseleave', onMouseLeave);
+    return () => document.removeEventListener('mouseleave', onMouseLeave);
+  }, [eligible, pathname]);
+
+  const dismiss = () => {
+    setOpen(false);
+    track('exit_intent_dismissed', pathname);
+  };
+
+  const convert = () => {
+    setOpen(false);
+    track('exit_intent_converted', pathname);
+  };
+
+  if (!eligible) return null;
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          <motion.div
+            key="exit-backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 z-[90] bg-black/60 backdrop-blur-sm"
+            onClick={dismiss}
+            aria-hidden="true"
+          />
+          <motion.div
+            key="exit-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="exit-intent-title"
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            transition={{ duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] }}
+            className="fixed left-1/2 top-1/2 z-[100] -translate-x-1/2 -translate-y-1/2 w-[92vw] max-w-md bg-card text-card-foreground rounded-2xl shadow-2xl border border-border p-6 md:p-8"
+          >
+            <button
+              type="button"
+              onClick={dismiss}
+              className="absolute top-3 right-3 rounded-full p-1.5 text-muted-foreground hover:bg-muted transition-colors"
+              aria-label="Cerrar"
+            >
+              <X className="h-5 w-5" />
+            </button>
+
+            <h2 id="exit-intent-title" className="text-xl md:text-2xl font-bold mb-2 pr-6">
+              ¿Te gustaría una cotización personalizada en 60 segundos?
+            </h2>
+            <p className="text-sm md:text-base text-muted-foreground mb-5">
+              Completa 3 preguntas rápidas y un especialista te contacta hoy.
+            </p>
+
+            <div className="flex flex-col gap-2 mb-5">
+              <Link
+                href="/cotizar?v=multistep&utm_source=exit_intent"
+                onClick={convert}
+                className="inline-flex items-center justify-center w-full rounded-xl bg-teal-600 hover:bg-teal-700 text-white font-semibold py-3 px-4 text-base transition-colors"
+              >
+                Cotizar ahora
+              </Link>
+              <Button type="button" variant="ghost" onClick={dismiss} className="rounded-xl">
+                No, gracias
+              </Button>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 pt-4 text-xs text-muted-foreground border-t border-border/50">
+              <span className="inline-flex items-center gap-1.5">
+                <ShieldCheck className="h-4 w-4 text-emerald-600" />
+                <span>OS-10 Certificados</span>
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Zap className="h-4 w-4 text-amber-500" />
+                <span>Respuesta en menos de 1 hora</span>
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Lock className="h-4 w-4 text-blue-600" />
+                <span>Sin compromiso</span>
+              </span>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## Resumen

Sprint 2 — dos mecanismos de recuperación de leads que se montan sobre la variante multistep introducida en Sprint 1B.

**Hipótesis:**
1. Usuarios que completan los pasos 1-3 (zero-typing) y abandonan en el paso 4 (datos personales) son alta intención. Capturarlos en `localStorage` y mostrarles un banner de retorno reduce la pérdida.
2. Usuarios que muestran intent de salir de páginas comerciales (`/servicios`, `/ciudades`, `/industrias`) sin haber convertido son recuperables vía un popup que ofrece la cotización express.

> **Base del PR:** este PR está abierto contra `feat/sprint-1b-multistep-form` (PR #26), no contra `main`. Mergear PR #26 primero, después este. Cuando mergees PR #26, este PR se rebasará automáticamente contra main.

## Cambios

### `app/cotizar/components/CotizacionFormMultiStep.tsx`
- Helpers `savePartialLead` / `getPartialLead` / `clearPartialLead` en `localStorage` con clave `gard_partial_lead_v1` y TTL 24h.
- `useEffect` al montar: detecta partial lead pendiente y muestra banner amber arriba del progress bar.
- `useEffect` al entrar al paso 4: persiste selecciones (industria/cobertura/cantidad) antes de capturar datos personales.
- Submit exitoso → `clearPartialLead()`. Reset y restart también limpian.
- Banner con dos acciones:
  - **Sí, continuar** → restaura selecciones, salta a paso 4, oculta banner.
  - **Empezar de cero** → limpia storage, oculta banner, queda en paso 1.
- Animación entrada/salida con framer-motion (fade + slide-down).

### `components/ExitIntentPopup.tsx` (nuevo)
- Client component con `usePathname` para evaluar elegibilidad.
- Listener `mouseleave` con `clientY < 10` → detecta intent de salir por arriba.
- Reglas de activación:
  - Desktop only (`window.innerWidth >= 768`).
  - Una vez por sesión (`sessionStorage.gard_exit_popup_shown`).
  - Mínimo 15s en la página antes de poder activarse.
  - Blacklist de paths: `/cotizar`, `/cotizador-inteligente`, `/portal-cliente`, `/reclutamiento`, `/admin`.
- Modal con backdrop oscuro, click-outside dismiss, X en esquina, accesibilidad (`role="dialog"`, `aria-modal`, `aria-labelledby`).
- CTA: `Link` a `/cotizar?v=multistep&utm_source=exit_intent`.
- Trust signals consistentes con el resto del flujo (OS-10, <1h, sin compromiso).

### `app/layout.tsx`
- Import + render de `<ExitIntentPopup />` justo antes del `<Footer />`. El componente decide internamente si activarse según pathname.

## Tracking dataLayer

| Evento | Dónde | Payload |
|---|---|---|
| `cotiz_partial_lead_detected` | Al montar el multistep si hay lead pendiente | `variant: 'multistep'` |
| `cotiz_partial_lead_resumed` | Click "Sí, continuar" | `variant` |
| `cotiz_partial_lead_dismissed` | Click "Empezar de cero" | `variant` |
| `exit_intent_shown` | Al detectarse el mouseleave válido | `page_path` |
| `exit_intent_converted` | Click "Cotizar ahora" | `page_path` |
| `exit_intent_dismissed` | Click "No, gracias" / X / backdrop | `page_path` |

## Diff stats

```
app/cotizar/components/CotizacionFormMultiStep.tsx | 133 ++++++++++++++++++
app/layout.tsx                                     |   2 +
components/ExitIntentPopup.tsx                     | 153 +++++++++++++++++++++
3 files changed, 288 insertions(+)
```

## Test plan

- [x] `npm run build` pasa sin errores ni warnings.
- [x] Pages `/cotizar?v=multistep` y `/servicios` HTTP 200.
- [x] Bundle del layout contiene `exit_intent_shown` y otros markers del popup.
- [x] Bundle de `/cotizar` contiene `gard_partial_lead_v1` y `cotiz_partial_lead_detected`.
- [ ] **Verificación manual en browser:**
  - [ ] `/cotizar?v=multistep` → completar pasos 1-3 → cerrar pestaña.
  - [ ] DevTools → Application → Local Storage tiene `gard_partial_lead_v1` con timestamp.
  - [ ] Reabrir `/cotizar?v=multistep` → ver banner amber arriba del progress bar.
  - [ ] Click "Sí, continuar" → salta a paso 4 con datos pre-aplicados; submit funciona.
  - [ ] Después de submit exitoso, `gard_partial_lead_v1` desaparece de storage.
  - [ ] `/servicios` en desktop → mover cursor rápido hacia barra de URL del navegador después de 15s → popup aparece.
  - [ ] Cerrar popup, refresh, otra vez intent → no reaparece (sessionStorage).
  - [ ] `/servicios` en mobile (375px) → no aparece popup.
  - [ ] `/cotizar` directo → popup NO aparece (path en blacklist).

## Dependencias

- Sprint 1B (PR #26) debe mergearse primero (este PR está basado en él).

## Próximo paso

Sprint 3 — A/B test formal con asignación 50/50 server-side por cookie + middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new client-side lead-recovery behavior in the quote funnel and a modal injected from `app/layout.tsx`, which could impact navigation/UX and analytics tracking across many pages if eligibility logic misfires.
> 
> **Overview**
> Adds **progressive lead capture** to the multistep cotización flow by persisting steps 1–3 selections to `localStorage` (24h TTL) when users reach step 4, showing a banner on return to resume or discard that saved state, and clearing it after successful submit.
> 
> Introduces a **desktop-only exit-intent modal** (once per session, after 15s) that fires on top-edge mouse leave, tracks `dataLayer` events, and routes users to `/cotizar?v=multistep&utm_source=exit_intent`; it’s mounted globally via `app/layout.tsx` with path-based suppression for non-target areas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db3e160faf5dc520ded62e1c328e312a5619f111. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->