### PR TITLE
feat(ab-test): asignación 50/50 server-side para CotizacionForm (Sprint 3)

### DIFF
--- a/app/cotizar/CotizarPageClient.tsx
+++ b/app/cotizar/CotizarPageClient.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import CotizacionForm from './components/CotizacionForm';
+import CotizacionFormMultiStep from './components/CotizacionFormMultiStep';
+import UrlParamsProcessor from './components/UrlParamsProcessor';
+import { ArrowRight, Clipboard } from 'lucide-react';
+import GardHero from '@/components/layouts/GardHero';
+import { Suspense } from 'react';
+import type { CotizarVariant } from '@/lib/ab-testing';
+
+interface CotizarPageClientProps {
+  variant: CotizarVariant;
+}
+
+export default function CotizarPageClient({ variant }: CotizarPageClientProps) {
+  // Función para desplazar al formulario cuando se hace clic en el botón del Hero
+  const scrollToForm = () => {
+    const formSection = document.querySelector('.gard-section');
+    if (formSection) {
+      formSection.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
+  return (
+    <>
+      {/* Componente para procesar parámetros URL */}
+      <Suspense fallback={null}>
+        <UrlParamsProcessor />
+      </Suspense>
+
+      {/* Hero Section */}
+      <GardHero
+        title="Cotiza tu Servicio de Seguridad"
+        subtitle="Completa el formulario y te enviaremos una propuesta personalizada"
+        ctaTexto="Completar Formulario"
+        onScrollToForm={scrollToForm}
+        badge={{
+          icon: <Clipboard className="h-4 w-4" />,
+          text: 'Cotización Personalizada',
+        }}
+        videoId="ac93b4a10e87873748171425b9f8066d"
+        imageId="09f20a0c-b345-4db8-ff81-14aad098db00"
+        overlay={true}
+      />
+
+      {/* Formulario de cotización */}
+      <section className="gard-section py-16 md:py-24">
+        <div className="gard-container max-w-7xl mx-auto px-4">
+          <div className="grid grid-cols-1 md:grid-cols-12 gap-8">
+            <div className="md:col-span-5">
+              <h2 className="text-heading-2 mb-6">Solicita tu cotización personalizada</h2>
+              <p className="text-body-lg text-muted-foreground mb-8">
+                En Gard Security te ofrecemos soluciones adaptadas específicamente a tus necesidades de seguridad. Completa el formulario y nuestro equipo te contactará en menos de 12 horas hábiles.
+              </p>
+
+              <div className="bg-muted/20 p-6 rounded-xl mb-8">
+                <h3 className="text-heading-4 mb-4">¿Por qué solicitar una cotización?</h3>
+                <ul className="space-y-3">
+                  <li className="flex items-start">
+                    <ArrowRight className="h-5 w-5 text-primary mr-2 mt-0.5 flex-shrink-0" />
+                    <span className="text-sm">Propuestas personalizadas según tus necesidades</span>
+                  </li>
+                  <li className="flex items-start">
+                    <ArrowRight className="h-5 w-5 text-primary mr-2 mt-0.5 flex-shrink-0" />
+                    <span className="text-sm">Presupuestos claros y sin sorpresas</span>
+                  </li>
+                  <li className="flex items-start">
+                    <ArrowRight className="h-5 w-5 text-primary mr-2 mt-0.5 flex-shrink-0" />
+                    <span className="text-sm">Rápida respuesta de nuestros especialistas</span>
+                  </li>
+                  <li className="flex items-start">
+                    <ArrowRight className="h-5 w-5 text-primary mr-2 mt-0.5 flex-shrink-0" />
+                    <span className="text-sm">Soluciones adaptadas a tu presupuesto</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="md:col-span-7">
+              {variant === 'multistep' ? <CotizacionFormMultiStep /> : <CotizacionForm />}
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/cotizar/components/CotizacionForm.tsx
+++ b/app/cotizar/components/CotizacionForm.tsx
@@ -28,6 +28,7 @@ import { useGtmEvent } from '../../components/EventTracker';
 import API_URLS from '@/app/config/api';
 import { getPaginaWebFromEmail } from '@/lib/opaiPayload';
 import { trackFormSubmission } from '@/lib/analytics/formTracking';
+import { getABVariantClient } from '@/lib/ab-testing-client';
 
 // Declaración para Google Maps API
 declare global {
@@ -156,6 +157,17 @@ export default function CotizacionForm({ prefillServicio, prefillIndustria }: Co
       }
     }
     fetchConfig();
+  }, []);
+
+  // A/B test exposure (Sprint 3)
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: 'cotizar_exposure',
+      ab_variant: getABVariantClient(),
+      variant_rendered: 'control',
+    });
   }, []);
 
   const form = useForm<FormValues>({
@@ -519,6 +531,7 @@ export default function CotizacionForm({ prefillServicio, prefillIndustria }: Co
             sessionStorage.removeItem('user_industry');
             sessionStorage.removeItem('user_service_slug');
             sessionStorage.removeItem('user_industry_slug');
+            const abVariant = getABVariantClient();
             trackFormSubmission({
               formType: 'cotizacion',
               additionalData: {
@@ -534,7 +547,15 @@ export default function CotizacionForm({ prefillServicio, prefillIndustria }: Co
                 landing_page: data.landing_page || '',
                 dotacion_puestos: data.dotacion?.length || 0,
                 dotacion_guardias: data.dotacion?.reduce((sum, d) => sum + d.cantidad, 0) || 0,
+                ab_variant: abVariant,
+                form_variant: 'control',
               }
+            });
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push({
+              event: 'cotizacion_submit',
+              ab_variant: abVariant,
+              form_variant: 'control',
             });
             break;
           }

--- a/app/cotizar/components/CotizacionFormMultiStep.tsx
+++ b/app/cotizar/components/CotizacionFormMultiStep.tsx
@@ -53,6 +53,7 @@ import {
 import API_URLS from '@/app/config/api';
 import { getPaginaWebFromEmail } from '@/lib/opaiPayload';
 import { trackFormSubmission } from '@/lib/analytics/formTracking';
+import { getABVariantClient } from '@/lib/ab-testing-client';
 
 declare global {
   interface Window {
@@ -444,6 +445,17 @@ export default function CotizacionFormMultiStep({ prefillServicio, prefillIndust
     savePartialLead(selections);
   }, [currentStep, selections]);
 
+  // A/B test exposure (Sprint 3) — emite una vez al montar el componente
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: 'cotizar_exposure',
+      ab_variant: getABVariantClient(),
+      variant_rendered: 'multistep',
+    });
+  }, []);
+
   // Google Maps loader (solo cuando se llega a step 4)
   useEffect(() => {
     if (currentStep !== 4) return;
@@ -601,6 +613,7 @@ export default function CotizacionFormMultiStep({ prefillServicio, prefillIndust
             setPartialLead(null);
             sessionStorage.removeItem('user_service');
             sessionStorage.removeItem('user_industry');
+            const abVariant = getABVariantClient();
             trackFormSubmission({
               formType: 'cotizacion',
               additionalData: {
@@ -610,9 +623,16 @@ export default function CotizacionFormMultiStep({ prefillServicio, prefillIndust
                 form_variant: 'multistep',
                 cobertura_seleccionada: selections.cobertura,
                 cantidad_bucket: selections.cantidadId,
+                ab_variant: abVariant,
               },
             });
-            trackStep(4, 'submit', { industria: data.tipoIndustria, cobertura: selections.cobertura });
+            trackStep(4, 'submit', { industria: data.tipoIndustria, cobertura: selections.cobertura, ab_variant: abVariant });
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push({
+              event: 'cotizacion_submit',
+              ab_variant: abVariant,
+              form_variant: 'multistep',
+            });
             break;
           }
           const errBody = await response.text().catch(() => '');

--- a/app/cotizar/page.tsx
+++ b/app/cotizar/page.tsx
@@ -1,92 +1,24 @@
-"use client";
+import { getCotizarVariant, type CotizarVariant } from '@/lib/ab-testing';
+import CotizarPageClient from './CotizarPageClient';
 
-import CotizacionForm from './components/CotizacionForm';
-import CotizacionFormMultiStep from './components/CotizacionFormMultiStep';
-import UrlParamsProcessor from './components/UrlParamsProcessor';
-import { ArrowRight, Clipboard } from 'lucide-react';
-import GardHero from '@/components/layouts/GardHero';
-import { Suspense } from 'react';
-import { useSearchParams } from 'next/navigation';
+// El experimento A/B requiere render dinámico por usuario para leer la cookie
+// asignada por middleware. Sin esto, Next puede prerenderizar y cachear la
+// respuesta, sirviendo la misma variante a todos.
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
-function CotizacionFormSwitch() {
-  const searchParams = useSearchParams();
-  const variant = searchParams?.get('v');
-  if (variant === 'multistep') return <CotizacionFormMultiStep />;
-  return <CotizacionForm />;
+interface CotizarPageProps {
+  searchParams: Promise<{ v?: string }>;
 }
 
-export default function CotizarPage() {
-  // Función para desplazar al formulario cuando se hace clic en el botón
-  const scrollToForm = () => {
-    const formSection = document.querySelector('.gard-section');
-    if (formSection) {
-      formSection.scrollIntoView({ behavior: 'smooth' });
-    }
-  };
+export default async function CotizarPage({ searchParams }: CotizarPageProps) {
+  const params = await searchParams;
 
-  return (
-    <>
-      {/* Componente para procesar parámetros URL */}
-      <Suspense fallback={null}>
-        <UrlParamsProcessor />
-      </Suspense>
+  // Override manual via query param (QA, links de email, debugging).
+  // Si no hay override, usa la variante asignada por cookie del middleware.
+  let variant: CotizarVariant = await getCotizarVariant();
+  if (params?.v === 'multistep') variant = 'multistep';
+  if (params?.v === 'control') variant = 'control';
 
-      {/* Hero Section */}
-      <GardHero 
-        title="Cotiza tu Servicio de Seguridad"
-        subtitle="Completa el formulario y te enviaremos una propuesta personalizada"
-        ctaTexto="Completar Formulario"
-        onScrollToForm={scrollToForm}
-        badge={{
-          icon: <Clipboard className="h-4 w-4" />,
-          text: "Cotización Personalizada"
-        }}
-        videoId="ac93b4a10e87873748171425b9f8066d"
-        imageId="09f20a0c-b345-4db8-ff81-14aad098db00"
-        overlay={true}
-      />
-
-      {/* Formulario de cotización */}
-      <section className="gard-section py-16 md:py-24">
-        <div className="gard-container max-w-7xl mx-auto px-4">
-          <div className="grid grid-cols-1 md:grid-cols-12 gap-8">
-            <div className="md:col-span-5">
-              <h2 className="text-heading-2 mb-6">Solicita tu cotización personalizada</h2>
-              <p className="text-body-lg text-muted-foreground mb-8">
-                En Gard Security te ofrecemos soluciones adaptadas específicamente a tus necesidades de seguridad. Completa el formulario y nuestro equipo te contactará en menos de 12 horas hábiles.
-              </p>
-              
-              <div className="bg-muted/20 p-6 rounded-xl mb-8">
-                <h3 className="text-heading-4 mb-4">¿Por qué solicitar una cotización?</h3>
-                <ul className="space-y-3">
-                  <li className="flex items-start">
-                    <ArrowRight className="h-5 w-5 text-primary mr-2 mt-0.5 flex-shrink-0" />
-                    <span className="text-sm">Propuestas personalizadas según tus necesidades</span>
-                  </li>
-                  <li className="flex items-start">
-                    <ArrowRight className="h-5 w-5 text-primary mr-2 mt-0.5 flex-shrink-0" />
-                    <span className="text-sm">Presupuestos claros y sin sorpresas</span>
-                  </li>
-                  <li className="flex items-start">
-                    <ArrowRight className="h-5 w-5 text-primary mr-2 mt-0.5 flex-shrink-0" />
-                    <span className="text-sm">Rápida respuesta de nuestros especialistas</span>
-                  </li>
-                  <li className="flex items-start">
-                    <ArrowRight className="h-5 w-5 text-primary mr-2 mt-0.5 flex-shrink-0" />
-                    <span className="text-sm">Soluciones adaptadas a tu presupuesto</span>
-                  </li>
-                </ul>
-              </div>
-            </div>
-            
-            <div className="md:col-span-7">
-              <Suspense fallback={<CotizacionForm />}>
-                <CotizacionFormSwitch />
-              </Suspense>
-            </div>
-          </div>
-        </div>
-      </section>
-    </>
-  );
+  return <CotizarPageClient variant={variant} />;
 }

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -1,0 +1,104 @@
+# A/B Testing — Cotizar form
+
+Guía de operación del experimento A/B activo en el flujo de cotización.
+
+## Experimento activo
+
+**Nombre interno:** `cotizar_form`
+**Variantes:**
+- `control` — formulario single-step (`CotizacionForm`)
+- `multistep` — formulario multi-step gamificado (`CotizacionFormMultiStep`, Sprint 1B)
+
+**Hipótesis:** dividir el formulario en 4 pasos donde los primeros 3 son zero-typing reduce la fricción inicial y mejora la conversión vs el single-step.
+
+## Asignación de variante
+
+- **Cookie:** `gard_ab_cotizar_form` (90 días, `SameSite=Lax`, `Secure` en producción).
+- **Asignación:** 50/50 aleatoria server-side por `middleware.ts` en la primera visita a paths del experimento.
+- **Persistencia:** una vez asignada, la cookie se mantiene 90 días — el mismo usuario siempre ve la misma variante.
+- **Lectura:**
+  - Server-side: `getCotizarVariant()` en [`lib/ab-testing.ts`](../lib/ab-testing.ts) (usa `next/headers` cookies).
+  - Client-side: `getABVariantClient()` en [`lib/ab-testing-client.ts`](../lib/ab-testing-client.ts) (lee `document.cookie`).
+
+### Paths donde se setea la cookie
+
+Configurado en [`middleware.ts`](../middleware.ts) — la cookie se asigna al visitar:
+- `/cotizar`
+- `/ciudades/*`
+- `/industrias/*`
+- `/servicios/*`
+- `/empresa-seguridad-privada-chile`
+- `/guardias-de-seguridad-privada-para-empresas`
+
+## Override manual
+
+Para QA, links de email y debugging:
+
+- `/cotizar?v=multistep` → fuerza la variante multistep para esa visita (ignora la cookie).
+- `/cotizar?v=control` → fuerza la variante control.
+
+El override **no modifica la cookie** — solo afecta el render de esa request.
+
+## Tracking en GA4 (vía dataLayer)
+
+| Evento | Cuándo | Payload clave |
+|---|---|---|
+| `cotizar_exposure` | Al montar cualquiera de los dos forms | `ab_variant`, `variant_rendered` |
+| `cotizacion_submit` | Al envío exitoso del formulario | `ab_variant`, `form_variant` |
+| `form_submission` (existente) | Al envío exitoso (vía `trackFormSubmission`) | `ab_variant` agregado al payload |
+| `cotiz_step_completed` | (multistep only) Al avanzar de paso | `step_number`, `variant: 'multistep'` |
+
+**Métrica primaria del experimento:**
+```
+Conversion rate por variante = count(cotizacion_submit) / count(cotizar_exposure)
+```
+
+agrupado por `ab_variant` (`control` vs `multistep`).
+
+**Métricas secundarias (multistep only):**
+- Tasa de avance paso a paso (`cotiz_step_completed`).
+- Tasa de retorno desde partial lead (`cotiz_partial_lead_resumed` / `cotiz_partial_lead_detected`).
+
+## Criterios para declarar ganador
+
+- **Significancia estadística:** 95% de confianza (p < 0.05).
+- **Tamaño mínimo de muestra:** 1,000 exposures por variante (≈2,000 totales).
+- **Duración mínima recomendada:** 2 ciclos completos de tráfico semanal para evitar sesgos por día de la semana.
+
+Antes de declarar ganador, validar también:
+- Conversión por canal/UTM source (no solo agregada).
+- Performance en mobile vs desktop.
+- Que la variante perdedora no tenga un caso de uso particular donde gane (e.g. retorno orgánico vs paid).
+
+## Cómo terminar el experimento
+
+Cuando hay un ganador claro:
+
+1. **Si gana `multistep`:**
+   - En [`app/cotizar/page.tsx`](../app/cotizar/page.tsx), cambiar el render por defecto a `<CotizacionFormMultiStep />` ignorando cookie.
+   - Eliminar `CotizacionForm.tsx` (control) en sprint posterior.
+   - Considerar refactor para extraer el schema y `onSubmit` a un módulo compartido (hoy están duplicados intencionalmente — ver TODO en `CotizacionFormMultiStep.tsx`).
+2. **Si gana `control`:**
+   - Cambiar el render por defecto a `<CotizacionForm />`.
+   - Eliminar `CotizacionFormMultiStep.tsx` y `components/ExitIntentPopup.tsx` (este último apunta a `?v=multistep`).
+3. **En ambos casos:**
+   - Remover la lógica de cookie de [`middleware.ts`](../middleware.ts).
+   - Mantener `gard_ab_cotizar_form` en blacklist de cookies legales hasta que expire (90 días).
+   - Archivar este documento o actualizarlo para el próximo experimento.
+
+## Cambios futuros al experimento
+
+Si se necesita ajustar la asignación (e.g. 80/20 hacia el ganador para acelerar la migración) o agregar una tercera variante:
+
+- Modificar la lógica en `middleware.ts` (la asignación es `Math.random() < 0.5`).
+- Agregar la nueva variante al type `CotizarVariant` en `lib/ab-testing-shared.ts`.
+- Actualizar el switch en `app/cotizar/page.tsx`.
+- Documentar el cambio aquí.
+
+## Referencias de implementación
+
+- Asignación + cookie: [`middleware.ts`](../middleware.ts)
+- Reader server: [`lib/ab-testing.ts`](../lib/ab-testing.ts)
+- Reader client + tipos compartidos: [`lib/ab-testing-client.ts`](../lib/ab-testing-client.ts), [`lib/ab-testing-shared.ts`](../lib/ab-testing-shared.ts)
+- Switch render: [`app/cotizar/page.tsx`](../app/cotizar/page.tsx)
+- Tracking exposure/submit: [`app/cotizar/components/CotizacionForm.tsx`](../app/cotizar/components/CotizacionForm.tsx), [`app/cotizar/components/CotizacionFormMultiStep.tsx`](../app/cotizar/components/CotizacionFormMultiStep.tsx)

--- a/lib/ab-testing-client.ts
+++ b/lib/ab-testing-client.ts
@@ -1,0 +1,14 @@
+// Helper client-side para leer la variante asignada por la cookie A/B.
+// Server-side usa lib/ab-testing.ts (next/headers cookies()).
+
+import { AB_COOKIE_NAME, type CotizarVariant } from './ab-testing-shared';
+
+export type ABVariantClient = CotizarVariant | 'unknown';
+
+export function getABVariantClient(): ABVariantClient {
+  if (typeof document === 'undefined') return 'unknown';
+  const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${AB_COOKIE_NAME}=([^;]+)`));
+  if (!match) return 'unknown';
+  const value = match[1];
+  return value === 'control' || value === 'multistep' ? value : 'unknown';
+}

--- a/lib/ab-testing-shared.ts
+++ b/lib/ab-testing-shared.ts
@@ -1,0 +1,8 @@
+// Constantes compartidas entre el reader server-side (lib/ab-testing.ts) y
+// el reader client-side (lib/ab-testing-client.ts). Este módulo no importa
+// nada de next/* para que pueda ser bundleado en cualquier entorno.
+
+export const AB_COOKIE_NAME = 'gard_ab_cotizar_form';
+export const AB_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 90; // 90 días
+
+export type CotizarVariant = 'control' | 'multistep';

--- a/lib/ab-testing.ts
+++ b/lib/ab-testing.ts
@@ -1,0 +1,22 @@
+import { cookies } from 'next/headers';
+import { AB_COOKIE_NAME, type CotizarVariant } from './ab-testing-shared';
+
+export { AB_COOKIE_NAME, AB_COOKIE_MAX_AGE_SECONDS, type CotizarVariant } from './ab-testing-shared';
+
+function isVariant(value: string | undefined): value is CotizarVariant {
+  return value === 'control' || value === 'multistep';
+}
+
+/**
+ * Devuelve la variante asignada al usuario para el experimento de cotizar.
+ * Server-only. Si la cookie no existe (caso borde — e.g. visita directa sin
+ * pasar por middleware) asigna una variante aleatoria como fallback, pero
+ * NO la persiste — eso es responsabilidad del middleware en la siguiente
+ * navegación.
+ */
+export async function getCotizarVariant(): Promise<CotizarVariant> {
+  const cookieStore = await cookies();
+  const existing = cookieStore.get(AB_COOKIE_NAME)?.value;
+  if (isVariant(existing)) return existing;
+  return Math.random() < 0.5 ? 'control' : 'multistep';
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,22 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { esCombinacionValida } from '@/app/data/servicios-por-industria';
 
+// ── A/B test cotizar form (Sprint 3) ──
+const AB_COOKIE_NAME = 'gard_ab_cotizar_form';
+const AB_COOKIE_MAX_AGE = 60 * 60 * 24 * 90; // 90 días
+const AB_PATHS = [
+  '/cotizar',
+  '/ciudades',
+  '/industrias',
+  '/servicios',
+  '/empresa-seguridad-privada-chile',
+  '/guardias-de-seguridad-privada-para-empresas',
+];
+
+function isAbTestPath(pathname: string): boolean {
+  return AB_PATHS.some((p) => pathname === p || pathname.startsWith(p + '/'));
+}
+
 // Lista de ciudades válidas para comparar
 const CIUDADES_VALIDAS = [
   'santiago', 'valparaiso', 'concepcion', 'vina-del-mar', 'temuco', 'antofagasta',
@@ -53,15 +69,30 @@ export function middleware(request: NextRequest) {
   // Manejar URLs antiguas de landing-dinamico SOLAMENTE
   if (segments[0] === 'landing-dinamico' && segments.length === 3) {
     const [_, industria, servicio] = segments;
-    
+
     if (INDUSTRIAS_VALIDAS.includes(industria)) {
       url.pathname = `/servicios-por-industria/${servicio}/${industria}`;
       return NextResponse.redirect(url, 301);
     }
   }
-  
-  // Para todas las demás rutas, simplemente continuar
-  return NextResponse.next();
+
+  // ── A/B test: asignar cookie 50/50 en primera visita a paths relevantes ──
+  const response = NextResponse.next();
+  if (isAbTestPath(pathname)) {
+    const existing = request.cookies.get(AB_COOKIE_NAME)?.value;
+    if (existing !== 'control' && existing !== 'multistep') {
+      const variant: 'control' | 'multistep' = Math.random() < 0.5 ? 'control' : 'multistep';
+      response.cookies.set({
+        name: AB_COOKIE_NAME,
+        value: variant,
+        maxAge: AB_COOKIE_MAX_AGE,
+        path: '/',
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+      });
+    }
+  }
+  return response;
 }
 
 function isValidRoute(segments: string[]): boolean {

--- a/next.config.js
+++ b/next.config.js
@@ -201,6 +201,15 @@ const nextConfig = {
           { key: 'X-Robots-Tag', value: 'all' },
           { key: 'Cache-Control', value: 'public, max-age=86400, s-maxage=86400' },
         ],
+      },
+      {
+        // /cotizar usa cookies para asignar variante A/B; debe servirse fresh
+        // por usuario para que cada uno vea SU variante (no la cacheada).
+        source: '/cotizar',
+        headers: [
+          { key: 'Cache-Control', value: 'private, no-store, max-age=0, must-revalidate' },
+          { key: 'Vary', value: 'Cookie' },
+        ],
       }
     ];
   }


### PR DESCRIPTION
## Resumen

Sprint 3 — A/B test formal del flujo de cotización. Reemplaza el A/B manual con `?v=` del Sprint 1B (que dependía de Suspense fallback y mostraba la variante correcta solo tras hidratación) por una **asignación 50/50 server-side persistente por cookie**.

**Resultado:** cada usuario ve consistentemente la misma variante en cada visita durante 90 días, el render es server-side sin flicker, y los eventos de exposure/submit incluyen `ab_variant` para análisis estadístico.

## Cómo funciona

1. Usuario visita `/cotizar` (o cualquier path elegible) por primera vez.
2. `middleware.ts` detecta que no hay cookie y asigna 50/50 → setea `gard_ab_cotizar_form=control` o `gard_ab_cotizar_form=multistep` (90 días).
3. `/cotizar` (server component) lee la cookie via `next/headers`, decide qué componente renderizar.
4. El render llega al usuario con la variante correcta — sin Suspense, sin flicker.
5. Visitas posteriores leen la misma cookie → misma variante.

## Cambios

### Asignación + lectura de cookie

- **`middleware.ts`** — agrega lógica que setea la cookie en primera visita a `/cotizar`, `/ciudades/*`, `/industrias/*`, `/servicios/*`, `/empresa-seguridad-privada-chile`, `/guardias-de-seguridad-privada-para-empresas`. Cookie con `Max-Age=7776000` (90 días), `SameSite=Lax`, `Secure` en producción. Mergeado con la lógica existente (WWW redirect + landing-dinamico).
- **`lib/ab-testing-shared.ts`** — constantes y tipos compartidos sin imports de `next/*`, bundleable en cualquier entorno.
- **`lib/ab-testing.ts`** — `getCotizarVariant()` server-side via `cookies()`.
- **`lib/ab-testing-client.ts`** — `getABVariantClient()` lee `document.cookie` para tracking.

### Refactor del page

- **`app/cotizar/page.tsx`** — convertido a server component async. Lee cookie + searchParams, decide variante, delega al cliente. Marcado `force-dynamic` + `revalidate=0`.
- **`app/cotizar/CotizarPageClient.tsx`** (nuevo) — todo el JSX cliente anterior (Hero + scrollToForm + sidebar + form). Recibe `variant` como prop.

### Cache override

- **`next.config.js`** — override de `Cache-Control` para `/cotizar` a `private, no-store, max-age=0, must-revalidate` + `Vary: Cookie`. Imprescindible porque el catch-all global aplicaba `public, s-maxage=86400` que cacheaba la respuesta y rompía el A/B.

### Tracking

Ambos forms emiten:
- `cotizar_exposure` al montar (`ab_variant`, `variant_rendered`).
- `cotizacion_submit` al envío exitoso (`ab_variant`, `form_variant`).
- `ab_variant` agregado al payload de `form_submission` (evento existente).

### Documentación

- **`docs/ab-testing.md`** (nuevo) — protocolo completo del experimento: asignación, override manual, tracking, criterios de ganador (95% confianza, ≥1k exposures por variante), cómo terminar.

## Override manual (mantenido)

Para QA, links de email y debugging:
- `/cotizar?v=multistep` → fuerza multistep ignorando cookie.
- `/cotizar?v=control` → fuerza control.

El override **no modifica la cookie** — solo afecta esa request.

## Diff stats

```
app/cotizar/CotizarPageClient.tsx                  |  87 +++++++++++++++++
app/cotizar/components/CotizacionForm.tsx          |  21 +++++
app/cotizar/components/CotizacionFormMultiStep.tsx |  22 ++++-
app/cotizar/page.tsx                               | 104 ++++-----------------
docs/ab-testing.md                                 | 104 +++++++++++++++++++++
lib/ab-testing-client.ts                           |  14 +++
lib/ab-testing-shared.ts                           |   8 ++
lib/ab-testing.ts                                  |  22 +++++
middleware.ts                                      |  39 +++++++-
next.config.js                                     |   9 ++
10 files changed, 339 insertions(+), 91 deletions(-)
```

## Test plan

### Validaciones automatizadas (✅ ya hechas localmente)

- [x] `npm run build` pasa sin errores ni warnings, `/cotizar` aparece como `ƒ` (Dynamic).
- [x] Headers correctos: `Cache-Control: private, no-store`, `Set-Cookie: gard_ab_cotizar_form=...`.
- [x] **Distribución 50/50** verificada: 11 control / 9 multistep en 20 visitas independientes (~55%/45%, dentro de varianza esperada).
- [x] **Persistencia**: 3 visitas con misma cookie jar → siempre la misma variante.
- [x] **Override `?v=multistep`/`?v=control`** funciona aunque haya cookie.
- [x] **Blacklist**: `/blog` no setea cookie A/B.
- [x] **Otros AB_PATHS** (`/servicios`) sí setean cookie.

### Verificación manual en producción/preview (pendiente revisor)

- [ ] DevTools → Application → Cookies → ver `gard_ab_cotizar_form` con valor `control` o `multistep` después de visitar `/cotizar`.
- [ ] Ventana incógnita 1 → variante X. Ventana incógnita 2 → eventualmente variante Y (50/50 random).
- [ ] Hard refresh → misma variante.
- [ ] GA4 DebugView muestra `cotizar_exposure` con `ab_variant` al cargar; `cotizacion_submit` con `ab_variant` al envío.
- [ ] Submit del formulario sigue enviando lead a OPAI correctamente.

## Dependencias

- ✅ Sprints 1A, 1B, 2 ya mergeados a main.

## Próximo paso (post-merge)

Esperar 2-4 semanas con tráfico orgánico + paid para acumular exposures suficientes (≥1k por variante). Después analizar en GA4:
- `count(cotizacion_submit) / count(cotizar_exposure)` por `ab_variant`.
- Significancia estadística (95% confianza).
- Si gana multistep, eliminar `CotizacionForm.tsx` en sprint posterior y hacer multistep el default permanente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request-time behavior (middleware cookie assignment) and caching headers for `/cotizar`, so misconfiguration could skew experiment results or serve wrong variant per user, but changes are isolated to the cotizar flow and tracking.
> 
> **Overview**
> Introduces a server-assigned, cookie-persisted A/B test for the `/cotizar` flow, replacing the previous client/query-param switch with per-user variant selection (`control` vs `multistep`) read server-side and rendered without hydration flicker.
> 
> Adds middleware logic to set `gard_ab_cotizar_form` (90 days) on first visit across a defined set of marketing paths, plus new shared/server/client helpers in `lib/ab-testing*` to read the variant.
> 
> Updates both cotizar forms to emit GA4 `dataLayer` events for **exposure** and **successful submit**, and includes `ab_variant` in the existing `trackFormSubmission` payload. Forces `/cotizar` to be uncacheable per user via `force-dynamic`/`revalidate=0` and explicit `/cotizar` `Cache-Control` + `Vary: Cookie` headers, and documents the experiment in `docs/ab-testing.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c90005bb24f6cc848a418334ee61c2cf2a6ef05. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->