### PR TITLE
fix(cotizar): alinear copy "12 horas" / "próximos minutos" → "1 hora"

### DIFF
--- a/app/components/cotizador/CotizadorInteligenteV2.tsx
+++ b/app/components/cotizador/CotizadorInteligenteV2.tsx
@@ -781,7 +781,7 @@ export default function CotizadorInteligenteV2() {
                 <Send className="h-4 w-4" />
                 <span>Solicitar Cotización</span>
               </button>
-              <p className="text-xs text-muted-foreground mt-3">Te contactaremos en los próximos minutos en horario hábil.</p>
+              <p className="text-xs text-muted-foreground mt-3">Te contactaremos en menos de 1 hora en horario hábil.</p>
             </div>
           </motion.div>
           

--- a/app/cotizar/CotizarPageClient.tsx
+++ b/app/cotizar/CotizarPageClient.tsx
@@ -50,7 +50,7 @@ export default function CotizarPageClient({ variant }: CotizarPageClientProps) {
             <div className="md:col-span-5">
               <h2 className="text-heading-2 mb-6">Solicita tu cotización personalizada</h2>
               <p className="text-body-lg text-muted-foreground mb-8">
-                En Gard Security te ofrecemos soluciones adaptadas específicamente a tus necesidades de seguridad. Completa el formulario y nuestro equipo te contactará en menos de 12 horas hábiles.
+                En Gard Security te ofrecemos soluciones adaptadas específicamente a tus necesidades de seguridad. Completa el formulario y nuestro equipo te contactará en menos de 1 hora en horario hábil.
               </p>
 
               <div className="bg-muted/20 p-6 rounded-xl mb-8">

--- a/app/cotizar/components/CotizacionForm.tsx
+++ b/app/cotizar/components/CotizacionForm.tsx
@@ -590,7 +590,7 @@ export default function CotizacionForm({ prefillServicio, prefillIndustria }: Co
             </svg>
           </div>
           <h2 className="text-heading-4 text-primary mb-4">¡Tu solicitud ha sido enviada correctamente!</h2>
-          <p className="text-body-base mb-6">Nuestro equipo comercial revisará tu requerimiento y te contactará en menos de 12 horas hábiles.</p>
+          <p className="text-body-base mb-6">Nuestro equipo comercial revisará tu requerimiento y te contactará en menos de 1 hora en horario hábil.</p>
           <div className="flex flex-col sm:flex-row gap-3 justify-center items-center mb-6">
             <a
               href={`https://wa.me/56982307771?text=${encodeURIComponent(

--- a/app/cotizar/components/CotizacionFormMultiStep.tsx
+++ b/app/cotizar/components/CotizacionFormMultiStep.tsx
@@ -712,7 +712,7 @@ export default function CotizacionFormMultiStep({ prefillServicio, prefillIndust
             </svg>
           </div>
           <h2 className="text-heading-4 text-primary mb-4">¡Tu solicitud ha sido enviada!</h2>
-          <p className="text-body-base mb-6">Te contactaremos en los próximos minutos en horario hábil.</p>
+          <p className="text-body-base mb-6">Te contactaremos en menos de 1 hora en horario hábil.</p>
           <div className="flex flex-col sm:flex-row gap-3 justify-center items-center mb-2">
             <a
               href={`https://wa.me/56982307771?text=${encodeURIComponent(


### PR DESCRIPTION
## Resumen

Hotfix: en `/cotizar` el sidebar prometía "menos de 12 horas hábiles" mientras el badge debajo del submit prometía "menos de 1 hora" — inconsistencia visible al cliente. Además los modales de éxito prometían "los próximos minutos en horario hábil" lo que es irrealista operativamente.

Unifico todo a **"menos de 1 hora en horario hábil"** para consistencia.

## Cambios

- [app/cotizar/CotizarPageClient.tsx](app/cotizar/CotizarPageClient.tsx) — sidebar
- [app/cotizar/components/CotizacionForm.tsx](app/cotizar/components/CotizacionForm.tsx) — modal de éxito (control)
- [app/cotizar/components/CotizacionFormMultiStep.tsx](app/cotizar/components/CotizacionFormMultiStep.tsx) — modal de éxito (multistep)
- [app/components/cotizador/CotizadorInteligenteV2.tsx](app/components/cotizador/CotizadorInteligenteV2.tsx) — copy bajo CTA principal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cambio solo de copy en UI para alinear expectativas de tiempo de respuesta; no toca lógica de negocio ni flujos de envío.
> 
> **Overview**
> Unifica el texto mostrado al usuario sobre el tiempo de contacto post-cotización para evitar inconsistencias entre pantallas.
> 
> Actualiza el copy en `/cotizar` (sidebar) y en los estados de éxito de `CotizacionForm`/`CotizacionFormMultiStep`, además del CTA en `CotizadorInteligenteV2`, pasando de "12 horas"/"próximos minutos" a **"menos de 1 hora en horario hábil"**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87bf72ef8be1f20f1eee91c0fd3a7858ef260ae1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->