### PR TITLE
fix(header): copy del menú de servicios sin jerga interna

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -34,7 +34,7 @@ const navLinks = [
 // Mega Menu Data
 const megaMenuData = {
   Servicios: [
-    { title: 'Para Empresas (B2B)', href: '/guardias-de-seguridad-privada-para-empresas', desc: 'Landing comercial B2B: casos, comparativa, cotización rápida.' },
+    { title: 'Seguridad para Empresas', href: '/guardias-de-seguridad-privada-para-empresas', desc: 'Casos reales, comparativa de servicios y cotización rápida.' },
     { title: 'Guardias de Seguridad', href: '/servicios/guardias-de-seguridad', desc: 'Personal certificado OS10 para protección física.' },
     { title: 'Seguridad Electrónica', href: '/servicios/seguridad-electronica', desc: 'CCTV, alarmas y control de acceso avanzado.' },
     { title: 'Central de Monitoreo', href: '/servicios/central-monitoreo', desc: 'Vigilancia remota 24/7 con respuesta inmediata.' },


### PR DESCRIPTION
## Summary

El item del megamenú **Servicios → Para Empresas (B2B)** mostraba copy interno del equipo de marketing (\"Landing comercial B2B: casos, comparativa, cotización rápida.\") al cliente final, rompiendo el patrón del resto del menú (descripciones cortas y orientadas al usuario).

### Cambio

- **title**: \`Para Empresas (B2B)\` → \`Seguridad para Empresas\`
  - Diferencia mejor del item \"Guardias de Seguridad\" justo abajo.
  - Elimina la jerga \`(B2B)\` que el cliente no necesita.
- **desc**: \`Landing comercial B2B: casos, comparativa, cotización rápida.\` → \`Casos reales, comparativa de servicios y cotización rápida.\`
  - Sin las palabras internas \"landing\" / \"B2B\".
  - Consistente con el resto del menú (ej: \"Personal certificado OS10 para protección física.\").

El \`href\` no cambia: sigue apuntando a \`/guardias-de-seguridad-privada-para-empresas\`.

## Test plan

- [ ] Hover sobre **Servicios** en el header → primer item lee \"Seguridad para Empresas\" con la nueva descripción.
- [ ] Click → llega a \`/guardias-de-seguridad-privada-para-empresas\` (sin cambios).
- [ ] El resto del megamenú no cambia (Guardias, Electrónica, Monitoreo, Drones, Auditoría, Consultoría).
- [ ] \`npm run build\` pasa (verificado localmente).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cambio solo de texto visible en el mega menú del header; no altera rutas, lógica de navegación ni manejo de datos.
> 
> **Overview**
> Actualiza el copy del primer ítem en el mega menú **Servicios** del `Header` para eliminar jerga interna: cambia el `title` a "Seguridad para Empresas" y reescribe la `desc` para ser más orientada al usuario.
> 
> El `href` se mantiene igual, por lo que la navegación y el comportamiento del menú no cambian.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1c8eb5f4b17a3c53e321a87db4d3de8013bb88c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->