### PR TITLE
Footer: consultas comerciales solo por correo

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -339,29 +339,16 @@ export default function Footer() {
                 <div className="mb-2">
                   <span className="font-semibold text-primary dark:text-accent text-sm block">Consultas Comerciales</span>
                 </div>
-                <div className="space-y-2">
-                  <div className="flex items-start gap-2">
-                    <Phone className="w-5 h-5 text-primary dark:text-blue-300 flex-shrink-0 mt-1" />
-                    <a 
-                      href="tel:+56968727644" 
-                      className="text-sm md:text-base text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors"
-                      aria-label="+56 9 6872 7644"
-                      itemProp="telephone"
-                    >
-                      +56 9 6872 7644
-                    </a>
-                  </div>
-                  <div className="flex items-start gap-2">
-                    <Mail className="w-5 h-5 text-primary dark:text-blue-300 flex-shrink-0 mt-1" />
-                    <a 
-                      href="mailto:comercial@gard.cl" 
-                      className="text-sm md:text-base text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors"
-                      aria-label="comercial@gard.cl"
-                      itemProp="email"
-                    >
-                      comercial@gard.cl
-                    </a>
-                  </div>
+                <div className="flex items-start gap-2">
+                  <Mail className="w-5 h-5 text-primary dark:text-blue-300 flex-shrink-0 mt-1" />
+                  <a 
+                    href="mailto:comercial@gard.cl" 
+                    className="text-sm md:text-base text-gray-700 dark:text-blue-100 hover:text-primary dark:hover:text-white transition-colors"
+                    aria-label="comercial@gard.cl"
+                    itemProp="email"
+                  >
+                    comercial@gard.cl
+                  </a>
                 </div>
               </li>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Quita el número de teléfono de la sección "Consultas Comerciales" del footer y deja únicamente el enlace a `comercial@gard.cl`. El teléfono de "Trabaja con nosotros" no se modifica.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c034a813-be33-4bae-addc-bf9973164f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c034a813-be33-4bae-addc-bf9973164f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

