### PR TITLE
feat(seo): GSC setup — analytics, verification, key fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,14 @@ NEXT_PUBLIC_GTM_ID=GTM-W9QM4NMC
 # Google Analytics 4 ID (ya configurado en GTM, pero aquí por referencia)
 NEXT_PUBLIC_GA_ID=G-4XJ2YKYYDH
 
+# Google Search Console — meta tag de verificación de propiedad
+# GSC → Settings → Ownership verification → HTML tag (solo el valor del content=)
+NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=
+
+# Google Search Console API (GitHub Actions secrets — NO commitear valores reales)
+# GSC_SERVICE_ACCOUNT_EMAIL=
+# GSC_SERVICE_ACCOUNT_KEY=
+
 # Google Maps JavaScript API + Places (autocomplete de direcciones).
 # Restringir en Google Cloud Console por HTTP referrer a *.gard.cl/* y localhost.
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=

--- a/.github/workflows/gsc-analytics-weekly.yml
+++ b/.github/workflows/gsc-analytics-weekly.yml
@@ -1,0 +1,52 @@
+name: GSC Search Analytics export
+
+on:
+  schedule:
+    # Lunes 04:00 UTC — baseline semanal para el plan SEO.
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    name: Export top GSC keywords
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.7.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run GSC analytics export
+        env:
+          GSC_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GSC_SERVICE_ACCOUNT_EMAIL }}
+          GSC_SERVICE_ACCOUNT_KEY: ${{ secrets.GSC_SERVICE_ACCOUNT_KEY }}
+          GSC_ANALYTICS_DAYS: "28"
+          GSC_ANALYTICS_ROW_LIMIT: "25"
+        run: pnpm run gsc-analytics
+
+      - name: Upload analytics artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gsc-analytics-report
+          path: |
+            docs/seo-baseline-latest.md
+            cowork-logs/gsc-analytics-*.json
+          if-no-files-found: ignore
+          retention-days: 90

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 
+const googleSiteVerification = process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION?.trim();
+
 export const metadata: Metadata = {
   metadataBase: new URL('https://www.gard.cl'),
   title: {
@@ -64,4 +66,7 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  ...(googleSiteVerification
+    ? { verification: { google: googleSiteVerification } }
+    : {}),
 }; 

--- a/docs/GSC-INDEXING-SETUP.md
+++ b/docs/GSC-INDEXING-SETUP.md
@@ -26,8 +26,9 @@ usa `node:crypto` + `fetch` nativos.
    - Role: **ninguno** (no necesita permisos IAM).
    - Done.
 
-2. **Habilitar Indexing API**
-   - [Google Cloud Console → APIs & Services → Library](https://console.cloud.google.com/apis/library) → "Indexing API" → Enable.
+2. **Habilitar APIs en Google Cloud**
+   - [Indexing API](https://console.cloud.google.com/apis/library/indexing.googleapis.com) → Enable (submit de URLs).
+   - [Google Search Console API](https://console.cloud.google.com/apis/library/searchconsole.googleapis.com) → Enable (export semanal de keywords vía `pnpm run gsc-analytics`).
 
 3. **Descargar credentials JSON**
    - En el service account recién creado → Keys → Add key → Create new key → JSON.
@@ -182,6 +183,7 @@ Priorización recomendada (el script respeta el orden del array):
 | 403 | Indexing API no habilitada | Paso 2 del setup |
 | 429 | Quota excedida (200/día por default) | Bajar `GSC_INDEXING_MAX_PER_RUN` o esperar 24h |
 | 400 | URL inválida o no pertenece al property verificado | Revisar `recently-updated.json` |
+| `DECODER routines::unsupported` | `GSC_SERVICE_ACCOUNT_KEY` mal pegada en GitHub Secrets | Regenerar secret con `jq -r .private_key credentials.json` y correr `pnpm run gsc-verify` localmente antes de guardar |
 
 ---
 
@@ -197,7 +199,40 @@ Si la indexación no mejora, el problema no es el API sino el contenido
 
 ---
 
-## Quota
+## Verificación HTML (meta tag)
+
+Si la propiedad aún no está verificada, o querés redundancia DNS + HTML:
+
+1. GSC → **Settings → Ownership verification → HTML tag**.
+2. Copiá solo el valor del atributo `content=` (sin comillas).
+3. En Vercel → **Environment Variables** → `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` (Production).
+4. Redeploy. El tag se inyecta vía `app/metadata.ts`.
+
+---
+
+## Export semanal de keywords (Search Analytics API)
+
+- Script: `scripts/automations/gsc-search-analytics-export.ts`
+- Comando: `pnpm run gsc-analytics`
+- Workflow: `.github/workflows/gsc-analytics-weekly.yml` (lunes 04:00 UTC)
+- Output: `docs/seo-baseline-latest.md` + artifact `gsc-analytics-report`
+
+Usa los mismos secrets `GSC_SERVICE_ACCOUNT_*` que el Indexing API cron.
+
+---
+
+## Checklist GSC completo (manual en dashboard)
+
+| Item | Dónde | Estado |
+|------|--------|--------|
+| Property `https://www.gard.cl/` verificada | Settings → Ownership | Manual |
+| Sitemap enviado | Sitemaps → Add `https://www.gard.cl/sitemap.xml` | Manual (ya en robots.txt) |
+| Geo-target Chile | Legacy tools → International Targeting | Manual |
+| GA4 vinculado (`G-4XJ2YKYYDH`) | Settings → Associations | Manual |
+| Indexing API cron | GitHub Actions → GSC Indexing API cron | ✅ Configurado |
+| Analytics export semanal | GitHub Actions → GSC Search Analytics export | ✅ Nuevo |
+| Meta verification tag | Vercel env `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` | Pendiente token |
+
 
 - **200 URLs/día** por defecto (ajustable vía env var `GSC_INDEXING_MAX_PER_RUN`).
 - Google recomienda oficialmente usar Indexing API solo para URLs tipo

--- a/docs/seo-baseline-latest.md
+++ b/docs/seo-baseline-latest.md
@@ -1,0 +1,22 @@
+# Baseline SEO · Google Search Console
+
+> Placeholder — se regenera con `pnpm run gsc-analytics` o el workflow semanal **GSC Search Analytics export**.
+
+## Cómo generar
+
+```bash
+export GSC_SERVICE_ACCOUNT_EMAIL="..."
+export GSC_SERVICE_ACCOUNT_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+pnpm run gsc-analytics
+```
+
+Requisito extra en Google Cloud: habilitar **Google Search Console API** (además de Indexing API).
+
+## Checklist manual en Search Console
+
+- [ ] Property `https://www.gard.cl/` verificada
+- [ ] Sitemap `https://www.gard.cl/sitemap.xml` enviado (también declarado en robots.txt)
+- [ ] International Targeting → **Chile**
+- [ ] Asociar GA4 `G-4XJ2YKYYDH` (Settings → Associations)
+- [ ] Service account con rol **Owner** (Indexing API) o al menos acceso al property (Search Analytics)
+- [ ] Revisar semanalmente: Pages, Core Web Vitals, Experience → HTTPS

--- a/lib/seo/search-console.ts
+++ b/lib/seo/search-console.ts
@@ -1,0 +1,20 @@
+/**
+ * Constantes de Google Search Console para gard.cl.
+ * Fuente única para sitemap, property URL y rutas de API.
+ */
+export const searchConsoleConfig = {
+  /** Property preferida (URL-prefix con www). */
+  siteUrl: 'https://www.gard.cl/',
+  /** Variantes que GSC puede registrar según cómo se verificó el dominio. */
+  propertyCandidates: [
+    'https://www.gard.cl/',
+    'https://gard.cl/',
+    'sc-domain:gard.cl',
+  ] as const,
+  sitemapUrl: 'https://www.gard.cl/sitemap.xml',
+  robotsUrl: 'https://www.gard.cl/robots.txt',
+  /** País objetivo en International Targeting (config manual en GSC). */
+  geoTarget: 'Chile (CL)' as const,
+} as const;
+
+export type SearchConsoleConfig = typeof searchConsoleConfig;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "typecheck": "tsc --noEmit",
     "test": "echo 'No tests configured yet'",
     "validate-ciudad": "tsx scripts/validate-ciudad-content.ts",
-    "gsc-indexing": "tsx scripts/automations/gsc-indexing-submit.ts"
+    "gsc-indexing": "tsx scripts/automations/gsc-indexing-submit.ts",
+    "gsc-analytics": "tsx scripts/automations/gsc-search-analytics-export.ts",
+    "gsc-verify": "tsx scripts/automations/gsc-verify-credentials.ts"
   },
   "dependencies": {
     "@cloudflare/stream-react": "^1.9.3",

--- a/scripts/automations/gsc-indexing-submit.ts
+++ b/scripts/automations/gsc-indexing-submit.ts
@@ -80,15 +80,53 @@ function base64url(input: Buffer | string): string {
 }
 
 /**
+ * Normaliza private_key desde GitHub Secrets, .env o jq (newlines reales vs \\n).
+ */
+function normalizePrivateKey(raw: string): string {
+  let key = raw.trim();
+
+  if (key.startsWith('"') && key.endsWith('"')) {
+    try {
+      key = JSON.parse(key) as string;
+    } catch {
+      key = key.slice(1, -1).replace(/\\n/g, '\n');
+    }
+  }
+
+  key = key.replace(/\\n/g, '\n');
+
+  if (key.includes('-----BEGIN') && !key.includes('\n')) {
+    key = key
+      .replace(/-----BEGIN ([A-Z ]+)-----/, '-----BEGIN $1-----\n')
+      .replace(/-----END ([A-Z ]+)-----/, '\n-----END $1-----\n');
+  }
+
+  if (
+    !key.includes('-----BEGIN PRIVATE KEY-----') &&
+    !key.includes('-----BEGIN RSA PRIVATE KEY-----')
+  ) {
+    throw new Error(
+      'GSC_SERVICE_ACCOUNT_KEY inválida: falta header PEM. Usá: jq -r .private_key credentials.json',
+    );
+  }
+
+  return key.endsWith('\n') ? key : `${key}\n`;
+}
+
+/**
  * Crea un JWT firmado con RS256 para el Google service account flow.
  * https://developers.google.com/identity/protocols/oauth2/service-account
  */
-function signServiceAccountJwt(clientEmail: string, privateKey: string): string {
+function signServiceAccountJwt(
+  clientEmail: string,
+  privateKey: string,
+  scope: string = SCOPE,
+): string {
   const now = Math.floor(Date.now() / 1000);
   const header = { alg: 'RS256', typ: 'JWT' };
   const payload = {
     iss: clientEmail,
-    scope: SCOPE,
+    scope,
     aud: TOKEN_ENDPOINT,
     exp: now + 3600,
     iat: now,
@@ -97,7 +135,15 @@ function signServiceAccountJwt(clientEmail: string, privateKey: string): string 
   const signer = createSign('RSA-SHA256');
   signer.update(unsigned);
   signer.end();
-  const signature = signer.sign(privateKey.replace(/\\n/g, '\n'));
+  let signature: Buffer;
+  try {
+    signature = signer.sign(normalizePrivateKey(privateKey));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `No se pudo firmar JWT — revisá GSC_SERVICE_ACCOUNT_KEY en GitHub Secrets: ${msg}`,
+    );
+  }
   return `${unsigned}.${base64url(signature)}`;
 }
 
@@ -306,4 +352,4 @@ if (import.meta.url === entrypointUrl) {
   });
 }
 
-export { main as runGscIndexing, publishWithRetry, signServiceAccountJwt };
+export { main as runGscIndexing, normalizePrivateKey, publishWithRetry, signServiceAccountJwt };

--- a/scripts/automations/gsc-search-analytics-export.ts
+++ b/scripts/automations/gsc-search-analytics-export.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env -S tsx
+/**
+ * Exporta top keywords de Google Search Console (últimos 28 días).
+ *
+ * Requiere las mismas credenciales que gsc-indexing-submit.ts y que el
+ * service account tenga acceso al property en Search Console (Owner o Full).
+ *
+ * Habilitar en Google Cloud: "Google Search Console API".
+ *
+ * Env vars:
+ *   GSC_SERVICE_ACCOUNT_EMAIL
+ *   GSC_SERVICE_ACCOUNT_KEY
+ *   GSC_ANALYTICS_DAYS        — opcional, default 28
+ *   GSC_ANALYTICS_ROW_LIMIT   — opcional, default 25
+ *
+ * Output: docs/seo-baseline-latest.md (+ cowork-logs/gsc-analytics-<ISO>.json)
+ */
+
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { searchConsoleConfig } from '../../lib/seo/search-console';
+import { signServiceAccountJwt } from './gsc-indexing-submit';
+
+const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
+const WEBMASTERS_SCOPE = 'https://www.googleapis.com/auth/webmasters.readonly';
+const WEBMASTERS_BASE = 'https://www.googleapis.com/webmasters/v3';
+
+type SearchAnalyticsRow = {
+  keys?: string[];
+  clicks?: number;
+  impressions?: number;
+  ctr?: number;
+  position?: number;
+};
+
+function env(name: string): string | undefined {
+  const v = process.env[name];
+  return v && v.length > 0 ? v : undefined;
+}
+
+function requireEnv(name: string): string {
+  const v = env(name);
+  if (!v) {
+    throw new Error(`Falta env var requerida: ${name}`);
+  }
+  return v;
+}
+
+async function getAccessToken(clientEmail: string, privateKey: string): Promise<string> {
+  const jwt = signServiceAccountJwt(clientEmail, privateKey, WEBMASTERS_SCOPE);
+  const body = new URLSearchParams({
+    grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+    assertion: jwt,
+  });
+  const res = await fetch(TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  if (!res.ok) {
+    throw new Error(`Token exchange falló: ${res.status} ${await res.text()}`);
+  }
+  const json = (await res.json()) as { access_token?: string };
+  if (!json.access_token) {
+    throw new Error('Respuesta sin access_token.');
+  }
+  return json.access_token;
+}
+
+async function listAccessibleSites(token: string): Promise<string[]> {
+  const res = await fetch(`${WEBMASTERS_BASE}/sites`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`List sites falló: ${res.status} ${await res.text()}`);
+  }
+  const json = (await res.json()) as { siteEntry?: Array<{ siteUrl?: string }> };
+  return (json.siteEntry ?? [])
+    .map((entry) => entry.siteUrl)
+    .filter((url): url is string => Boolean(url));
+}
+
+function resolveSiteUrl(accessible: string[]): string {
+  for (const candidate of searchConsoleConfig.propertyCandidates) {
+    if (accessible.includes(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    `No se encontró property de gard.cl. Accesibles: ${accessible.join(', ') || '(ninguno)'}. ` +
+      'Agregá el service account como usuario en Search Console.',
+  );
+}
+
+function formatDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+async function querySearchAnalytics(
+  token: string,
+  siteUrl: string,
+  startDate: string,
+  endDate: string,
+  rowLimit: number,
+): Promise<SearchAnalyticsRow[]> {
+  const encodedSite = encodeURIComponent(siteUrl);
+  const res = await fetch(`${WEBMASTERS_BASE}/sites/${encodedSite}/searchAnalytics/query`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      startDate,
+      endDate,
+      dimensions: ['query'],
+      rowLimit,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`searchAnalytics/query falló: ${res.status} ${await res.text()}`);
+  }
+  const json = (await res.json()) as { rows?: SearchAnalyticsRow[] };
+  return json.rows ?? [];
+}
+
+function toMarkdown(
+  siteUrl: string,
+  startDate: string,
+  endDate: string,
+  rows: SearchAnalyticsRow[],
+): string {
+  const lines = [
+    '# Baseline SEO · Google Search Console',
+    '',
+    `> Generado automáticamente · ${new Date().toISOString()}`,
+    '',
+    `- **Property**: \`${siteUrl}\``,
+    `- **Período**: ${startDate} → ${endDate}`,
+    `- **Sitemap**: ${searchConsoleConfig.sitemapUrl}`,
+    '',
+    '## Top keywords (clicks)',
+    '',
+    '| Query | Clicks | Impresiones | CTR | Posición avg |',
+    '| --- | ---: | ---: | ---: | ---: |',
+  ];
+
+  if (rows.length === 0) {
+    lines.push('| _(sin datos en el período)_ | — | — | — | — |');
+  } else {
+    for (const row of rows) {
+      const query = row.keys?.[0] ?? '(unknown)';
+      const clicks = row.clicks ?? 0;
+      const impressions = row.impressions ?? 0;
+      const ctr = row.ctr != null ? `${(row.ctr * 100).toFixed(1)}%` : '—';
+      const position = row.position != null ? row.position.toFixed(1) : '—';
+      lines.push(`| ${query.replace(/\|/g, '\\|')} | ${clicks} | ${impressions} | ${ctr} | ${position} |`);
+    }
+  }
+
+  lines.push(
+    '',
+    '## Checklist manual en Search Console',
+    '',
+    '- [ ] Sitemap `https://www.gard.cl/sitemap.xml` enviado y sin errores',
+    '- [ ] International Targeting → Chile',
+    '- [ ] Vincular propiedad GA4 (`G-4XJ2YKYYDH`) en Settings → Associations',
+    '- [ ] Revisar Core Web Vitals y Pages → Indexación semanalmente',
+    '',
+  );
+
+  return lines.join('\n');
+}
+
+export async function runGscAnalyticsExport(): Promise<void> {
+  const days = Number.parseInt(env('GSC_ANALYTICS_DAYS') ?? '28', 10);
+  const rowLimit = Number.parseInt(env('GSC_ANALYTICS_ROW_LIMIT') ?? '25', 10);
+
+  const end = new Date();
+  const start = new Date(end);
+  start.setDate(start.getDate() - days);
+
+  const startDate = formatDate(start);
+  const endDate = formatDate(end);
+
+  const clientEmail = requireEnv('GSC_SERVICE_ACCOUNT_EMAIL');
+  const privateKey = requireEnv('GSC_SERVICE_ACCOUNT_KEY');
+
+  const token = await getAccessToken(clientEmail, privateKey);
+  const accessible = await listAccessibleSites(token);
+  const siteUrl = resolveSiteUrl(accessible);
+
+  const rows = await querySearchAnalytics(token, siteUrl, startDate, endDate, rowLimit);
+  const markdown = toMarkdown(siteUrl, startDate, endDate, rows);
+
+  const docsPath = join(process.cwd(), 'docs', 'seo-baseline-latest.md');
+  writeFileSync(docsPath, markdown, 'utf8');
+  console.log(`Escrito: ${docsPath} (${rows.length} queries)`);
+
+  const logDir = join(process.cwd(), 'cowork-logs');
+  if (!existsSync(logDir)) {
+    mkdirSync(logDir, { recursive: true });
+  }
+  const logPath = join(
+    logDir,
+    `gsc-analytics-${new Date().toISOString().replace(/[:.]/g, '-')}.json`,
+  );
+  writeFileSync(
+    logPath,
+    JSON.stringify({ siteUrl, startDate, endDate, rowCount: rows.length, rows }, null, 2),
+    'utf8',
+  );
+  console.log(`Log: ${logPath}`);
+}
+
+if (import.meta.url === `file://${process.argv[1] ?? ''}`) {
+  runGscAnalyticsExport().catch((err: unknown) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/automations/gsc-verify-credentials.ts
+++ b/scripts/automations/gsc-verify-credentials.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env -S tsx
+/**
+ * Verifica que GSC_SERVICE_ACCOUNT_* permiten obtener un access token.
+ * Útil antes de re-configurar GitHub Secrets o tras rotar la clave.
+ *
+ *   export GSC_SERVICE_ACCOUNT_EMAIL="..."
+ *   export GSC_SERVICE_ACCOUNT_KEY="$(jq -r .private_key credentials.json)"
+ *   pnpm run gsc-verify
+ */
+
+import { signServiceAccountJwt } from './gsc-indexing-submit';
+
+const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
+const INDEXING_SCOPE = 'https://www.googleapis.com/auth/indexing';
+
+function requireEnv(name: string): string {
+  const v = process.env[name]?.trim();
+  if (!v) {
+    throw new Error(`Falta env var: ${name}`);
+  }
+  return v;
+}
+
+async function main(): Promise<void> {
+  const email = requireEnv('GSC_SERVICE_ACCOUNT_EMAIL');
+  const key = requireEnv('GSC_SERVICE_ACCOUNT_KEY');
+
+  const jwt = signServiceAccountJwt(email, key, INDEXING_SCOPE);
+  const res = await fetch(TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: jwt,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Token exchange falló (${res.status}): ${await res.text()}`);
+  }
+
+  const json = (await res.json()) as { access_token?: string };
+  if (!json.access_token) {
+    throw new Error('Respuesta sin access_token.');
+  }
+
+  console.log('OK: credenciales GSC válidas (JWT firmado + token obtenido).');
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Meta tag de verificación GSC vía `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`
- Export semanal de keywords (`pnpm run gsc-analytics` + workflow lunes)
- `normalizePrivateKey()` para corregir fallos del cron Indexing API (`DECODER routines::unsupported`)
- Script `pnpm run gsc-verify` para validar credenciales antes de guardar secrets

## Post-merge (manual)
1. Re-guardar `GSC_SERVICE_ACCOUNT_KEY` en GitHub Secrets:
   ```bash
   jq -r .private_key credentials.json | gh secret set GSC_SERVICE_ACCOUNT_KEY
   ```
2. Correr `pnpm run gsc-verify` localmente para confirmar
3. Actions → **GSC Indexing API cron** → Run workflow
4. Habilitar **Search Console API** en Google Cloud
5. Vercel: `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` si aplica

## Test plan
- [ ] `pnpm run gsc-verify` con credenciales locales
- [ ] Workflow GSC Indexing pasa en GitHub Actions
- [ ] Workflow GSC Search Analytics export genera artifact

Made with [Cursor](https://cursor.com)