### PR TITLE
fix(seo): quitar AggregateRating self-serving del schema (errores GSC)

### DIFF
--- a/components/seo/LocalBusinessSchema.tsx
+++ b/components/seo/LocalBusinessSchema.tsx
@@ -60,17 +60,13 @@ export default function LocalBusinessSchema() {
       }
     ],
 
-    // Rating agregado — verificable vía url con Google Business Profile.
-    // Los valores se leen de companyStats.gmbRatingValue / gmbReviewCount
-    // (single source of truth). Última verificación manual: ver companyStats.
-    "aggregateRating": {
-      "@type": "AggregateRating",
-      "ratingValue": companyStats.gmbRatingValue,
-      "bestRating": companyStats.gmbBestRating,
-      "worstRating": companyStats.gmbWorstRating,
-      "reviewCount": companyStats.gmbReviewCount,
-      "url": companyStats.gmbShortUrl
-    },
+    // NOTA: NO se emite aggregateRating aquí. Un rating de la propia empresa
+    // sobre sí misma es "self-serving review" según la política de Google
+    // (2019+) y Search Console lo marca como inválido en TODAS las páginas
+    // ("Invalid object type for field parent_node" / "multiple aggregate
+    // ratings"). Las estrellas en el SERP provienen del Google Business
+    // Profile, no de este markup. Los valores reales siguen en
+    // companyStats.gmb* para uso en UI verificable (links a GMB).
 
     // Áreas de servicio
     "areaServed": [

--- a/components/seo/ReviewSchema.tsx
+++ b/components/seo/ReviewSchema.tsx
@@ -56,6 +56,15 @@ export default function ReviewSchema({ itemReviewed, aggregateRating, reviews, v
   // markup engañoso (riesgo de manual action). Para LocalBusiness/Organization
   // se enlaza con @id a la entidad global de LocalBusinessSchema para que los
   // validadores las fusionen en vez de crear una entidad duplicada.
+  // Sin reviews verificados no hay nada que emitir: el aggregateRating de la
+  // propia empresa es "self-serving review" (política Google 2019+) y Search
+  // Console lo marca como inválido. Las estrellas en SERP vienen del Google
+  // Business Profile. Solo emitimos schema cuando hay testimonios con
+  // consentimiento explícito en lib/data/testimonials.ts.
+  if (!hasVerifiedReviews) {
+    return null;
+  }
+
   const entityType = itemReviewed.type ?? 'LocalBusiness';
   const schema: Record<string, unknown> = {
     '@context': 'https://schema.org',
@@ -67,36 +76,26 @@ export default function ReviewSchema({ itemReviewed, aggregateRating, reviews, v
     url: itemReviewed.url,
     ...(itemReviewed.image ? { image: itemReviewed.image } : {}),
     ...(itemReviewed.description ? { description: itemReviewed.description } : {}),
-    aggregateRating: {
-      '@type': 'AggregateRating',
-      ratingValue: aggregateRating.ratingValue.toFixed(1),
-      reviewCount: aggregateRating.reviewCount,
-      bestRating: aggregateRating.bestRating ?? 5,
-      worstRating: aggregateRating.worstRating ?? 1,
-      ...(verificationUrl ? { url: verificationUrl } : {}),
-    },
     ...(verificationUrl ? { sameAs: [verificationUrl] } : {}),
   };
 
-  if (hasVerifiedReviews) {
-    schema.review = reviews!.map((review) => ({
-      '@type': 'Review',
-      name: review.name ?? `${itemReviewed.name} - Reseña`,
-      reviewBody: review.reviewBody,
-      datePublished: review.datePublished,
-      reviewRating: {
-        '@type': 'Rating',
-        ratingValue: review.ratingValue,
-        bestRating: aggregateRating.bestRating ?? 5,
-        worstRating: aggregateRating.worstRating ?? 1,
-      },
-      author: {
-        '@type': review.author.type ?? 'Person',
-        name: review.author.name,
-      },
-      ...(review.url ? { url: review.url } : {}),
-    }));
-  }
+  schema.review = reviews!.map((review) => ({
+    '@type': 'Review',
+    name: review.name ?? `${itemReviewed.name} - Reseña`,
+    reviewBody: review.reviewBody,
+    datePublished: review.datePublished,
+    reviewRating: {
+      '@type': 'Rating',
+      ratingValue: review.ratingValue,
+      bestRating: aggregateRating.bestRating ?? 5,
+      worstRating: aggregateRating.worstRating ?? 1,
+    },
+    author: {
+      '@type': review.author.type ?? 'Person',
+      name: review.author.name,
+    },
+    ...(review.url ? { url: review.url } : {}),
+  }));
 
   return (
     <script


### PR DESCRIPTION
## Contexto
Diagnóstico hecho conectándome a Google Search Console (propiedad `sc-domain:gard.cl`) vía API. GSC reportaba en datos estructurados:

- **"Invalid object type for field parent_node"** (Review snippets) en `/santiago/guardias-de-seguridad`, `/industrias/mineria` y todas las páginas
- **"Review has multiple aggregate ratings"** en `/blog`

## Causa
El `AggregateRating` (4.9★/57) del negocio se emitía en `LocalBusinessSchema` (global, en el layout raíz) → aparecía en **todas** las páginas. Google lo clasifica como **self-serving review** (política 2019+) e inválido para review snippets. Las estrellas del SERP vienen del Google Business Profile, no de este markup.

## Cambios
- `LocalBusinessSchema.tsx`: elimina el bloque `aggregateRating` (mantiene address, geo, sameAs, etc.)
- `ReviewSchema.tsx`: solo emite schema cuando hay reviews **verificados**; ya no emite el rating self-serving

## Impacto
- No se pierden estrellas reales (Google ya no las mostraba por ser self-serving)
- GSC debería dejar de marcar estos errores tras el recrawl
- Las cifras `companyStats.gmb*` siguen disponibles para UI con link verificable a GMB

## Test plan
- [ ] Build de Vercel preview en verde
- [ ] Validar páginas en https://validator.schema.org/ (sin AggregateRating)
- [ ] Tras merge + recrawl, confirmar en GSC que desaparecen los errores de Review snippets

Made with [Cursor](https://cursor.com)